### PR TITLE
[67] feat(checkpoint): introduce leave checkpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,14 @@ sampleRUM.drain('cwv', (() => {
   document.head.appendChild(script);
 }));
 
+sampleRUM.drain('leave', ((event = {}) => {
+  if (sampleRUM.left || (event.type === 'visibilitychange' && document.visibilityState !== 'hidden')) {
+    return;
+  }
+  sampleRUM.left = true;
+  sampleRUM('leave');
+}));
+
 sampleRUM.sourceselector = (element) => {
   if (element === document.body || element === document.documentElement || !element) {
     return undefined;
@@ -120,3 +128,6 @@ document.querySelectorAll('form').forEach((form) => {
     sampleRUM('formsubmit', { target: sampleRUM.targetselector(event.target), source: sampleRUM.sourceselector(event.target) });
   });
 });
+
+window.addEventListener('visibilitychange', ((event) => sampleRUM.leave(event)));
+window.addEventListener('pagehide', ((event) => sampleRUM.leave(event)));


### PR DESCRIPTION
## Related Issues
#67 

Add `visibilitychange` and `pagehide`  event listeners to detect when visitors are leaving a page, and introduce a `leave` checkpoint.

Things to note:
1. Only one `leave` checkpoint is sent per page view.
2. When user switches from one browser tab to another one, the `leave` checkpoint is also sent.
3. According to the some [benchmarks](https://www.speedkit.com/blog/unload-beacon-reliability-benchmarking-strategies-for-minimal-data-loss) approximately 9% of page leaves will be missed, with the combination of events we are tracking.
4. `visibilitychange` and `pagehide` events are not always properly managed in Chrome dev tools. See [bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=472282#c26). E.g. when a visitor clicks a link and goes to a different page. 
It is necessary to validate that leave checkpoints are really sent, regardless of what is shown in Chrome Dev Tools 