### PR TITLE
feat(navigate): refine checkpoints for `enter`, `navigate`, `reload`, `back_forward`, and `prerender`, track `visibilityState`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,10 +48,24 @@ sampleRUM.drain('observe', ((elements) => {
   });
 }));
 
-// enter checkpoint when referrer is not the current page url
-if (!!document.referrer && (document.referrer !== window.location.href)) {
-  sampleRUM('enter', { target: undefined, source: document.referrer });
-}
+const navigate = (source, type) => {
+  const payload = { source, target: document.visibilityState };
+  // reload: same page, navigate: same origin, enter: everything else
+  if (type === 'reload' || source === window.location.href) {
+    sampleRUM('reload', payload);
+  } else if (type !== 'navigate') {
+    sampleRUM(type, payload); // back, forward, prerender, etc.
+  } else if (source && window.location.origin === new URL(source).origin) {
+    sampleRUM('navigate', payload); // internal navigation
+  } else {
+    sampleRUM('enter', payload); // enter site
+  }
+};
+navigate(document.referrer);
+
+new PerformanceObserver((list) => list
+  .getEntries().map((entry) => navigate(document.referrer, entry.type)))
+  .observe({ entryTypes: ['navigation'], buffered: true });
 
 sampleRUM.targetselector = (element) => {
   let value = element.getAttribute('href') || element.currentSrc || element.getAttribute('src')

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ navigate(document.referrer);
 
 new PerformanceObserver((list) => list
   .getEntries().map((entry) => navigate(document.referrer, entry.type)))
-  .observe({ entryTypes: ['navigation'], buffered: true });
+  .observe({ type: 'navigation', buffered: true });
 
 sampleRUM.targetselector = (element) => {
   let value = element.getAttribute('href') || element.currentSrc || element.getAttribute('src')


### PR DESCRIPTION
 - `enter` will now fire for every page open that does not come from the same origin, including direct opens - `reload` tracks reloads or opens from the same exact page 
 - `back_forward` and `prerender` track what's on the tin 
 - `navigate` is all on-site navigation 
  
 in addition the `document.VisibilityState` is tracked in `target` allowing us to filter non-visible opens that are not performance critical and often throttled