### PR TITLE
Autotrack CTAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.9.1](https://github.com/adobe/helix-rum-enhancer/compare/v1.9.0...v1.9.1) (2024-01-11)
+
+
+### Bug Fixes
+
+* correct prefix check for relative urls in targets. fixes [#102](https://github.com/adobe/helix-rum-enhancer/issues/102) ([3df4132](https://github.com/adobe/helix-rum-enhancer/commit/3df413259cd0e71777328f738b81057f7f4e5520))
+
 # [1.9.0](https://github.com/adobe/helix-rum-enhancer/compare/v1.8.1...v1.9.0) (2023-12-11)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/helix-rum-enhancer",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Helix RUM Enhancer",
   "main": "src/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -124,8 +124,8 @@ sampleRUM.sourceselector = (element) => {
     formElementSelector = element.tagName === 'INPUT' ? `form input[type='${element.getAttribute('type')}']` : `form ${element.tagName.toLowerCase()}`;
   }
 
+  const blockName = element.closest('.block') ? element.closest('.block').getAttribute('data-block-name') : '';
   if (element.id || formElementSelector) {
-    const blockName = element.closest('.block') ? element.closest('.block').getAttribute('data-block-name') : '';
     const id = element.id ? `#${element.id}` : '';
     return blockName ? `.${blockName} ${formElementSelector}${id}` : `${formElementSelector}${id}`;
   }
@@ -133,6 +133,11 @@ sampleRUM.sourceselector = (element) => {
   if (element.getAttribute('data-block-name')) {
     return `.${element.getAttribute('data-block-name')}`;
   }
+
+  if (Array.from(element.classList).some((className) => className.match(/button|cta/))) {
+    return blockName ? `.${blockName} .button` : '.button';
+  }
+  
   return sampleRUM.sourceselector(element.parentElement);
 };
 


### PR DESCRIPTION
This PR tracks CTAs automatically in order to later compute CTRs.
The rule to track a CTA is simple: 
- the element that was clicked on has a class named `button` or `cta`

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
