### PR TITLE
feat(minirum): allow different base urls for collection and extra scripts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ function trackCheckpoint(checkpoint, data, t) {
     const sendPing = (pdata = data) => {
       // eslint-disable-next-line object-curly-newline, max-len
       const body = JSON.stringify({ weight, id, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'], checkpoint, t, ...data }, KNOWN_PROPERTIES);
-      const url = new URL(`.rum/${weight}`, sampleRUM.baseURL).href;
+      const url = new URL(`.rum/${weight}`, sampleRUM.collectBaseURL || sampleRUM.baseURL).href;
       navigator.sendBeacon(url, body);
       // eslint-disable-next-line no-console
       console.debug(`ping:${checkpoint}`, pdata);


### PR DESCRIPTION
Support for:
* `sampleRUM.collectBaseURL` : base url for rum collection (POST requests)
* `sampleRUM.baseURL` : base url for extra scripts: enhancer, webvitals, etc. (GET requests) 

