### PR TITLE
feat: track UTM query parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@
  */
 /* eslint-env browser */
 const KNOWN_PROPERTIES = ['weight', 'id', 'referer', 'checkpoint', 't', 'source', 'target', 'cwv', 'CLS', 'FID', 'LCP', 'INP', 'TTFB'];
-const DEFAULT_TRACKING_EVENTS = ['click', 'cwv', 'form', 'enterleave', 'viewblock', 'viewmedia', 'loadresource'];
+const DEFAULT_TRACKING_EVENTS = ['click', 'cwv', 'form', 'enterleave', 'viewblock', 'viewmedia', 'loadresource', 'utm'];
 const SESSION_STORAGE_KEY = 'aem-rum';
 const { sampleRUM, queue, isSelected } = window.hlx.rum;
 
@@ -224,6 +224,15 @@ function addViewMediaTracking(parent) {
   }
 }
 
+function addUTMParametersTracking() {
+  const usp = new URLSearchParams(window.location.search);
+  const utmParams = [...usp.entries()]
+    .filter(([key]) => key.startsWith('utm_') && key !== 'utm_id');
+  utmParams.forEach(([key, value]) => {
+    sampleRUM('utm-campaign', { source: key, target: value });
+  });
+}
+
 function addFormTracking(parent) {
   activateBlocksMutationObserver();
   parent.querySelectorAll('form').forEach((form) => {
@@ -254,6 +263,7 @@ function addTrackingFromConfig() {
     form: () => addFormTracking(window.document.body),
     enterleave: () => addEnterLeaveTracking(),
     loadresource: () => addLoadResourceTracking(),
+    utm: () => addUTMParametersTracking(),
     viewblock: () => addViewBlockTracking(window.document.body),
     viewmedia: () => addViewMediaTracking(window.document.body),
   };

--- a/src/index.js
+++ b/src/index.js
@@ -229,7 +229,7 @@ function addUTMParametersTracking() {
   const utmParams = [...usp.entries()]
     .filter(([key]) => key.startsWith('utm_') && key !== 'utm_id');
   utmParams.forEach(([key, value]) => {
-    sampleRUM('utm-campaign', { source: key, target: value });
+    sampleRUM('utm', { source: key, target: value });
   });
 }
 


### PR DESCRIPTION
This PR adds support for tracking UTM query parameters under the `utm` checkpoint.
All UTM parameters will be captured except for the `utm_id` which could be PII.

## Related Issues

Fix #137