### PR TITLE
feat: enable reportAllChanges for all projects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,6 @@ sampleRUM.drain('cwv', (() => {
       sampleRUM('cwv', data);
     };
 
-    const featureToggle = () => ['blog.adobe.com', 'www.revolt.tv'].includes(window.location.hostname);
     const isEager = (metric) => ['CLS', 'LCP'].includes(metric);
 
     // When loading `web-vitals` using a classic script, all the public
@@ -107,7 +106,7 @@ sampleRUM.drain('cwv', (() => {
     ['FID', 'INP', 'TTFB', 'CLS', 'LCP'].forEach((metric) => {
       const metricFn = window.webVitals[`on${metric}`];
       if (typeof metricFn === 'function') {
-        const opts = isEager(metric) ? { reportAllChanges: featureToggle() } : undefined;
+        const opts = isEager(metric) ? { reportAllChanges: true } : undefined;
         metricFn(storeCWV, opts);
       }
     });


### PR DESCRIPTION
The feature (https://github.com/GoogleChrome/web-vitals?tab=readme-ov-file#report-the-value-on-every-change) has been tested on blog.adobe.com and revolt.tv for a couple a weeks. On those 2 sites, we could observe an increase of reported number of LCP and CLS checkpoints in the RUM data. In some cases, it is up to 4x times more reported LCP events!
- LCP
  - there is only a trivial number (less than 1%) of extra requests (like 2 LCPs captured)
- CLS
  - this changes how the CLS is collected - every CLS event will fire a request (while aggregated before) - before the change, we saw 9% of sessions where CLS was captured multiple times. This number now goes to 25%. Nothing critical, just a little bit more entries to be filtered out in the data reporting.

I think it is time to enable the feature on all projects.