### PR TITLE
fix: exclude utm_term from collection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -243,8 +243,8 @@ function addUTMParametersTracking() {
   [...usp.entries()]
     .filter(([key]) => key.startsWith('utm_'))
     // exclude keys that may leak PII
-  .filter(([key]) => key !== 'utm_id')
-  .filter(([key]) => key !== 'utm_term')
+    .filter(([key]) => key !== 'utm_id')
+    .filter(([key]) => key !== 'utm_term')
     .forEach(([source, target]) => sampleRUM('utm', { source, target }));
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -242,7 +242,8 @@ function addUTMParametersTracking() {
   const usp = new URLSearchParams(window.location.search);
   [...usp.entries()]
     .filter(([key]) => key.startsWith('utm_'))
-    .filter(([key]) => key !== 'utm_id')
+    // exclude keys that may leak PII
+    .filter(([key]) => key !== 'utm_id' && key !== 'utm_term')
     .forEach(([source, target]) => sampleRUM('utm', { source, target }));
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -243,7 +243,8 @@ function addUTMParametersTracking() {
   [...usp.entries()]
     .filter(([key]) => key.startsWith('utm_'))
     // exclude keys that may leak PII
-    .filter(([key]) => key !== 'utm_id' && key !== 'utm_term')
+  .filter(([key]) => key !== 'utm_id')
+  .filter(([key]) => key !== 'utm_term')
     .forEach(([source, target]) => sampleRUM('utm', { source, target }));
 }
 


### PR DESCRIPTION
The `utm_term` is typically populated from search queries and can theoretically leak PII. So it's safest to exclude it from collection for now

Fix #153
