### PR TITLE
fix(backport): exclude utm_term from collection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,8 @@ new PerformanceObserver((list) => {
 
 [...new URLSearchParams(window.location.search).entries()]
   .filter(([key]) => key.startsWith('utm_'))
-  .filter(([key]) => key !== 'utm_id' && key !== 'utm_term')
+  .filter(([key]) => key !== 'utm_id')
+  .filter(([key]) => key !== 'utm_term')
   .forEach(([key, value]) => {
     sampleRUM('utm', { source: key, target: value });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ new PerformanceObserver((list) => {
 
 [...new URLSearchParams(window.location.search).entries()]
   .filter(([key]) => key.startsWith('utm_'))
-  .filter(([key]) => key !== 'utm_id')
+  .filter(([key]) => key !== 'utm_id' && key !== 'utm_term')
   .forEach(([key, value]) => {
     sampleRUM('utm', { source: key, target: value });
   });


### PR DESCRIPTION
The utm_term is typically populated from search queries and can theoretically leak PII. So it's safest to exclude it from collection for now

Fix #153