### PR TITLE
fix: no type leads to empty checkpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,6 @@ function addEnterLeaveTracking() {
       sampleRUM('enter', payload); // enter site
     }
   };
-  navigate(document.referrer);
 
   new PerformanceObserver((list) => list
     .getEntries().map((entry) => navigate(document.referrer, entry.type)))

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ function addEnterLeaveTracking() {
     // reload: same page, navigate: same origin, enter: everything else
     if (type === 'reload' || source === window.location.href) {
       sampleRUM('reload', payload);
-    } else if (type !== 'navigate') {
+    } else if (type && type !== 'navigate') {
       sampleRUM(type, payload); // back, forward, prerender, etc.
     } else if (source && window.location.origin === new URL(source).origin) {
       sampleRUM('navigate', payload); // internal navigation


### PR DESCRIPTION
I think the `addEnterLeaveTracking` logic is incorrect and we do not track enough data:
- `navigate(document.referrer);` is always called (line 172), i.e. `type` is always undefined
- test `if (type !== 'navigate')` is always true when `type` is undefined`. `sampleRUM(type, payload)` is always called with an empty `checkpoint`.

`enter` will then be equal to `pageload`.

I am not fully sure this is the expected tracking behavior because it also goes through the PerformanceObserver.

@trieloff @chicharr WDTY ?