### PR TITLE
fix: avoid CORS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,8 +110,13 @@ function trackCheckpoint(checkpoint, data, t) {
     const sendPing = (pdata = data) => {
       // eslint-disable-next-line object-curly-newline, max-len
       const body = JSON.stringify({ weight, id, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'], checkpoint, t, ...data }, KNOWN_PROPERTIES);
-      const url = new URL(`.rum/${weight}`, sampleRUM.collectBaseURL || sampleRUM.baseURL).href;
-      navigator.sendBeacon(url, body);
+      const { href: url, origin} = new URL(`.rum/${weight}`, sampleRUM.collectBaseURL || sampleRUM.baseURL);
+      if (window.location.origin === origin) {
+        const headers = { type: 'application/json' };
+        navigator.sendBeacon(url, new Blob([body], headers));
+      } else {
+        navigator.sendBeacon(url, body);
+      }
       // eslint-disable-next-line no-console
       console.debug(`ping:${checkpoint}`, pdata);
     };

--- a/src/index.js
+++ b/src/index.js
@@ -111,8 +111,7 @@ function trackCheckpoint(checkpoint, data, t) {
       // eslint-disable-next-line object-curly-newline, max-len
       const body = JSON.stringify({ weight, id, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'], checkpoint, t, ...data }, KNOWN_PROPERTIES);
       const url = new URL(`.rum/${weight}`, sampleRUM.collectBaseURL || sampleRUM.baseURL).href;
-      const headers = { type: 'application/json' };
-      navigator.sendBeacon(url, new Blob([body], headers));
+      navigator.sendBeacon(url, body);
       // eslint-disable-next-line no-console
       console.debug(`ping:${checkpoint}`, pdata);
     };


### PR DESCRIPTION
Not sure why `headers` is pased, it is not part of the method signature (see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon).
`body` is a string, no need to wrap into a blob.

This fixes the CORS issues.
