### PR TITLE
fix: no this in arrow functions (#182)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,11 @@
 const { sampleRUM } = window.hlx.rum;
 
 const fflags = {
-  has: (flag) => this[flag].indexOf(Array.from(window.origin)
+  has: (flag) => fflags[flag].indexOf(Array.from(window.origin)
     .map((a) => a.charCodeAt(0))
     .reduce((a, b) => a + b, 1) % 1371) !== -1,
-  enabled: (flag, callback) => this.has(flag) && callback(),
-  disabled: (flag, callback) => !this.has(flag) && callback(),
+  enabled: (flag, callback) => fflags.has(flag) && callback(),
+  disabled: (flag, callback) => !fflags.has(flag) && callback(),
   onetrust: [543, 770, 1136],
   ads: [1339],
   email: [1339],


### PR DESCRIPTION
For 1.x
