### PR TITLE
fix: add referer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,7 @@ function trackCheckpoint(checkpoint, data, t) {
   if (optedIn(checkpoint, data) && isSelected) {
     const sendPing = (pdata = data) => {
       // eslint-disable-next-line object-curly-newline, max-len
-      const body = JSON.stringify({ weight, id, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'], checkpoint, t, ...data }, KNOWN_PROPERTIES);
+      const body = JSON.stringify({ weight, id, referer: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'](), checkpoint, t, ...data }, KNOWN_PROPERTIES);
       const { href: url, origin} = new URL(`.rum/${weight}`, sampleRUM.collectBaseURL || sampleRUM.baseURL);
       if (window.location.origin === origin) {
         const headers = { type: 'application/json' };


### PR DESCRIPTION
Since there is no test, I do not know what the `sanitizeURL` may have been used for... but several things wrong with that code:
- the `sanitizeURL` property is set with a function (function not executed...)
- the `sanitizeURL` property is filter out because it is not in the `KNOWN_PROPERTIES`

Conclusion: no `sanitizeURL` but also no `referer`