### PR TITLE
fix: correct urlSanitizers implementation

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@
  */
 
 export const urlSanitizers = {
-  full: () => window.location.href,
-  origin: () => window.location.origin,
-  path: () => window.location.href.replace(/\?.*$/, ''),
+  full: (url = window.location.href) => new URL(url).toString(),
+  origin: (url = window.location.href) => new URL(url).origin,
+  path: (url = window.location.href) => new URL(url).pathname,
 };

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -19,15 +19,63 @@ describe('test utils#urlSanitizers', () => {
   it('urlSanitizers.full', () => {
     expect(urlSanitizers.full).to.be.a('function');
     expect(urlSanitizers.full()).to.be.a('string');
+
+    expect(urlSanitizers.full('https://wwww.sample.com')).to.be.equal('https://wwww.sample.com/');
+    expect(urlSanitizers.full('https://wwww.sample.com/')).to.be.equal('https://wwww.sample.com/');
+    expect(urlSanitizers.full('https://wwww.sample.com/index.html')).to.be.equal('https://wwww.sample.com/index.html');
+    expect(urlSanitizers.full('https://wwww.sample.com/path/')).to.be.equal('https://wwww.sample.com/path/');
+    expect(urlSanitizers.full('https://wwww.sample.com/path/page.html')).to.be.equal('https://wwww.sample.com/path/page.html');
+
+    expect(urlSanitizers.full('https://wwww.sample.com/path/page.html?a=1&b=2')).to.be.equal('https://wwww.sample.com/path/page.html?a=1&b=2');
+
+    expect(urlSanitizers.full('http://localhost:3000')).to.be.equal('http://localhost:3000/');
+    expect(urlSanitizers.full('http://localhost:3000/')).to.be.equal('http://localhost:3000/');
+    expect(urlSanitizers.full('http://localhost:3000/index.html')).to.be.equal('http://localhost:3000/index.html');
+    expect(urlSanitizers.full('http://localhost:3000/path/')).to.be.equal('http://localhost:3000/path/');
+    expect(urlSanitizers.full('http://localhost:3000/path/page.html')).to.be.equal('http://localhost:3000/path/page.html');
+
+    expect(urlSanitizers.full('http://localhost:3000/path/page.html?a=1&b=2')).to.be.equal('http://localhost:3000/path/page.html?a=1&b=2');
   });
 
   it('urlSanitizers.origin', () => {
     expect(urlSanitizers.origin).to.be.a('function');
     expect(urlSanitizers.origin()).to.be.a('string');
+
+    expect(urlSanitizers.origin('https://wwww.sample.com')).to.be.equal('https://wwww.sample.com');
+    expect(urlSanitizers.origin('https://wwww.sample.com/')).to.be.equal('https://wwww.sample.com');
+    expect(urlSanitizers.origin('https://wwww.sample.com/index.html')).to.be.equal('https://wwww.sample.com');
+    expect(urlSanitizers.origin('https://wwww.sample.com/path/')).to.be.equal('https://wwww.sample.com');
+    expect(urlSanitizers.origin('https://wwww.sample.com/path/page.html')).to.be.equal('https://wwww.sample.com');
+
+    expect(urlSanitizers.origin('https://wwww.sample.com/path/page.html?a=1&b=2')).to.be.equal('https://wwww.sample.com');
+
+    expect(urlSanitizers.origin('http://localhost:3000')).to.be.equal('http://localhost:3000');
+    expect(urlSanitizers.origin('http://localhost:3000/')).to.be.equal('http://localhost:3000');
+    expect(urlSanitizers.origin('http://localhost:3000/index.html')).to.be.equal('http://localhost:3000');
+    expect(urlSanitizers.origin('http://localhost:3000/path/')).to.be.equal('http://localhost:3000');
+    expect(urlSanitizers.origin('http://localhost:3000/path/page.html')).to.be.equal('http://localhost:3000');
+
+    expect(urlSanitizers.origin('http://localhost:3000/path/page.html?a=1&b=2')).to.be.equal('http://localhost:3000');
   });
 
   it('urlSanitizers.path', () => {
     expect(urlSanitizers.path).to.be.a('function');
     expect(urlSanitizers.path()).to.be.a('string');
+
+    expect(urlSanitizers.path('https://wwww.sample.com')).to.be.equal('/');
+    expect(urlSanitizers.path('https://wwww.sample.com/')).to.be.equal('/');
+    expect(urlSanitizers.path('https://wwww.sample.com/index.html')).to.be.equal('/index.html');
+    expect(urlSanitizers.path('https://wwww.sample.com/path/')).to.be.equal('/path/');
+    expect(urlSanitizers.path('https://wwww.sample.com/path/page.html')).to.be.equal('/path/page.html');
+
+    expect(urlSanitizers.path('https://wwww.sample.com/path/page.html')).to.be.equal('/path/page.html');
+
+    expect(urlSanitizers.path('http://localhost:3000')).to.be.equal('/');
+    expect(urlSanitizers.path('http://localhost:3000/')).to.be.equal('/');
+    expect(urlSanitizers.path('http://localhost:3000/index.html')).to.be.equal('/index.html');
+    expect(urlSanitizers.path('http://localhost:3000/path/')).to.be.equal('/path/');
+    expect(urlSanitizers.path('http://localhost:3000/path/page.html')).to.be.equal('/path/page.html');
+
+    expect(urlSanitizers.path('http://localhost:3000/path/page.html?a=1&b=2')).to.be.equal('/path/page.html');
   });
 });


### PR DESCRIPTION
Basic function with a lot of issues:
- need a parameter to make it testable
- weird `path` implementation
- is `path` supposed to return the query parameters or not ?

@chicharr @trieloff please check the implementation fixes... only the `path` function is used in the code (can be overriden via a variable). I tested the code with a sample page, only the path (with no query param) is sent now (before was the url) and it is correctly processed by the collector.