### PR TITLE
chore: stabilize test

### DIFF
--- a/test/it/utils.urlSanitizers.test.html
+++ b/test/it/utils.urlSanitizers.test.html
@@ -14,13 +14,13 @@
       describe('utils#urlSanitizers', () => {
         it('urlSanitizers.full', () => {
           const full = new URL(urlSanitizers.full());
-          expect(full.origin).to.be.equal('http://localhost:8000');
+          expect(full.origin).to.be.equal(window.location.origin);
           expect(full.pathname).to.be.equal('/test/it/utils.urlSanitizers.test.html');
         });
 
         it('urlSanitizers.origin', () => {
           const origin = urlSanitizers.origin();
-          expect(origin).to.be.equal('http://localhost:8000');
+          expect(origin).to.be.equal(window.location.origin);
         });
 
         it('urlSanitizers.path', () => {

--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -73,7 +73,7 @@ describe('test dom#targetSelector', () => {
   it('targetSelector - select target for relative link', () => {
     const a = document.createElement('a');
     a.setAttribute('href', '/target.html');
-    expect(targetSelector(a)).to.be.equal('http://localhost:8000/target.html');
+    expect(targetSelector(a)).to.be.equal(`${window.location.origin}/target.html`);
   });
 
   it('targetSelector - select target for span in a link', () => {
@@ -92,7 +92,7 @@ describe('test dom#targetSelector', () => {
     span.textContent = 'test';
     span.setAttribute('data-rum-target', 'test');
     a.append(span);
-    expect(targetSelector(span)).to.be.equal('http://localhost:8000/test');
+    expect(targetSelector(span)).to.be.equal(`${window.location.origin}/test`);
   });
 
   it('targetSelector - select target for img', () => {


### PR DESCRIPTION
Tests relying on hardcoded host name might be failing if default port is already occupied.