### PR TITLE
fix: restore original path behavior

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -11,7 +11,28 @@
  */
 
 export const urlSanitizers = {
+  /**
+   * Returns the full url.
+   * If no url is provided, it defaults to window.location.href.
+   * @param {string} url (default: window.location.href) The url to sanitize
+   * @returns {string} The sanitized url
+   */
   full: (url = window.location.href) => new URL(url).toString(),
+  /**
+   * Returns the origin of the provided url.
+   * If no url is provided, it defaults to window.location.href.
+   * @param {string} url (default: window.location.href) The url to sanitize
+   * @returns {string} The sanitized url
+   */
   origin: (url = window.location.href) => new URL(url).origin,
-  path: (url = window.location.href) => new URL(url).pathname,
+  /**
+   * Returns the sanitized url: the origin and the path (no query params or hash)
+   * If no url is provided, it defaults to window.location.href.
+   * @param {string} url (default: window.location.href) The url to sanitize
+   * @returns {string} The sanitized url
+   */
+  path: (url = window.location.href) => {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  },
 };

--- a/test/it/utils.urlSanitizers.test.html
+++ b/test/it/utils.urlSanitizers.test.html
@@ -16,6 +16,8 @@
           const full = new URL(urlSanitizers.full());
           expect(full.origin).to.be.equal(window.location.origin);
           expect(full.pathname).to.be.equal('/test/it/utils.urlSanitizers.test.html');
+          // tests have a search param, so we expect it to be present
+          expect(full.search).to.not.be.equal('');
         });
 
         it('urlSanitizers.origin', () => {
@@ -24,8 +26,10 @@
         });
 
         it('urlSanitizers.path', () => {
-          const path = urlSanitizers.path();
-          expect(path).to.be.equal('/test/it/utils.urlSanitizers.test.html');
+          const path = new URL(urlSanitizers.path());
+          expect(path.origin).to.be.equal(window.location.origin);
+          expect(path.pathname).to.be.equal('/test/it/utils.urlSanitizers.test.html');
+          expect(path.search).to.be.equal('');
         });
       });
     });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -62,20 +62,22 @@ describe('test utils#urlSanitizers', () => {
     expect(urlSanitizers.path).to.be.a('function');
     expect(urlSanitizers.path()).to.be.a('string');
 
-    expect(urlSanitizers.path('https://wwww.sample.com')).to.be.equal('/');
-    expect(urlSanitizers.path('https://wwww.sample.com/')).to.be.equal('/');
-    expect(urlSanitizers.path('https://wwww.sample.com/index.html')).to.be.equal('/index.html');
-    expect(urlSanitizers.path('https://wwww.sample.com/path/')).to.be.equal('/path/');
-    expect(urlSanitizers.path('https://wwww.sample.com/path/page.html')).to.be.equal('/path/page.html');
+    expect(urlSanitizers.path('https://wwww.sample.com')).to.be.equal('https://wwww.sample.com/');
+    expect(urlSanitizers.path('https://wwww.sample.com/')).to.be.equal('https://wwww.sample.com/');
+    expect(urlSanitizers.path('https://wwww.sample.com/index.html')).to.be.equal('https://wwww.sample.com/index.html');
+    expect(urlSanitizers.path('https://wwww.sample.com/path/')).to.be.equal('https://wwww.sample.com/path/');
+    expect(urlSanitizers.path('https://wwww.sample.com/path/page.html')).to.be.equal('https://wwww.sample.com/path/page.html');
 
-    expect(urlSanitizers.path('https://wwww.sample.com/path/page.html')).to.be.equal('/path/page.html');
+    expect(urlSanitizers.path('https://www.sample.com/?a=1&b=2')).to.be.equal('https://www.sample.com/');
+    expect(urlSanitizers.path('https://www.sample.com/path/page.html?a=1&b=2')).to.be.equal('https://www.sample.com/path/page.html');
 
-    expect(urlSanitizers.path('http://localhost:3000')).to.be.equal('/');
-    expect(urlSanitizers.path('http://localhost:3000/')).to.be.equal('/');
-    expect(urlSanitizers.path('http://localhost:3000/index.html')).to.be.equal('/index.html');
-    expect(urlSanitizers.path('http://localhost:3000/path/')).to.be.equal('/path/');
-    expect(urlSanitizers.path('http://localhost:3000/path/page.html')).to.be.equal('/path/page.html');
+    expect(urlSanitizers.path('http://localhost:3000')).to.be.equal('http://localhost:3000/');
+    expect(urlSanitizers.path('http://localhost:3000/')).to.be.equal('http://localhost:3000/');
+    expect(urlSanitizers.path('http://localhost:3000/index.html')).to.be.equal('http://localhost:3000/index.html');
+    expect(urlSanitizers.path('http://localhost:3000/path/')).to.be.equal('http://localhost:3000/path/');
+    expect(urlSanitizers.path('http://localhost:3000/path/page.html')).to.be.equal('http://localhost:3000/path/page.html');
 
-    expect(urlSanitizers.path('http://localhost:3000/path/page.html?a=1&b=2')).to.be.equal('/path/page.html');
+    expect(urlSanitizers.path('http://localhost:3000/?a=1&b=2')).to.be.equal('http://localhost:3000/');
+    expect(urlSanitizers.path('http://localhost:3000/path/page.html?a=1&b=2')).to.be.equal('http://localhost:3000/path/page.html');
   });
 });


### PR DESCRIPTION
I changed `path` implementation to return... the url pathname while it was expected to return the origin + pathame (no query param)