### PR TITLE
feat: add more logic to button selector

### DIFF
--- a/modules/dom.js
+++ b/modules/dom.js
@@ -55,27 +55,24 @@ export const sourceSelector = (element) => {
     }
 
     const classes = Array.from(element.classList);
+    const label = element.tagName.toLowerCase();
+    const firstClass = classes.length > 0 ? `.${classes[0]}` : '';
+    const labelWithClass = `${element.tagName.toLowerCase()}${firstClass}`;
     if (element.tagName.toLowerCase() === 'button'
       || element.type === 'button'
       || classes.some((className) => className.match(/button|cta/))) {
-      const label = element.tagName.toLowerCase();
-      const firstClass = classes.length > 0 ? `.${classes[0]}` : '';
-      const labelWithClass = `${element.tagName.toLowerCase()}${firstClass}`;
-
       let parent = element.parentElement;
-
       if (!parent) return labelWithClass;
-
       if (parent.id) return `#${parent.id} ${label}`;
-
       while (parent.tagName !== 'BODY' && !parent.id) parent = parent.parentElement;
-
       if (parent.id) return `#${parent.id} ${labelWithClass}`;
-
       return blockName ? `.${blockName} ${labelWithClass}` : labelWithClass;
     }
 
-    return sourceSelector(element.parentElement);
+    const parent = sourceSelector(element.parentElement);
+    if (parent) return parent;
+
+    return labelWithClass;
     /* c8 ignore next 3 */
   } catch (error) {
     return null;

--- a/modules/dom.js
+++ b/modules/dom.js
@@ -54,8 +54,25 @@ export const sourceSelector = (element) => {
       return `.${element.getAttribute('data-block-name')}`;
     }
 
-    if (Array.from(element.classList).some((className) => className.match(/button|cta/))) {
-      return blockName ? `.${blockName} .button` : '.button';
+    const classes = Array.from(element.classList);
+    if (element.tagName.toLowerCase() === 'button'
+      || element.type === 'button'
+      || classes.some((className) => className.match(/button|cta/))) {
+      const label = element.tagName.toLowerCase();
+      const firstClass = classes.length > 0 ? `.${classes[0]}` : '';
+      const labelWithClass = `${element.tagName.toLowerCase()}${firstClass}`;
+
+      let parent = element.parentElement;
+
+      if (!parent) return labelWithClass;
+
+      if (parent.id) return `#${parent.id} ${label}`;
+
+      while (parent.tagName !== 'BODY' && !parent.id) parent = parent.parentElement;
+
+      if (parent.id) return `#${parent.id} ${labelWithClass}`;
+
+      return blockName ? `.${blockName} ${labelWithClass}` : labelWithClass;
     }
 
     return sourceSelector(element.parentElement);

--- a/test/unit/dom.sourceSelector.buttons.test.html
+++ b/test/unit/dom.sourceSelector.buttons.test.html
@@ -1,0 +1,68 @@
+<html>
+
+<head>
+  <title>Test Runner</title>
+</head>
+
+<body>
+  <div id="test">
+    <div class="button-group">
+      <div class="banner-actions-container">
+        <button id="reject-all-handler">Decline All</button>
+        <button id="accept-btn-handler">Accept All</button>
+      </div>
+      <div id="close-btn-container">
+        <button class="close-btn-handler banner-close-button close-icon"></button>
+      </div>
+      <button class="orphan-btn-handler some-button"></button>
+    </div>
+    <div id="cta-container">
+      <input type="button" class="cta cta-1">
+    </div>
+  </div>
+  <div>
+    <button class="orphan button with many classes"></button>
+  </div>
+  <div>
+    <button class="a-btn"></button>
+  </div>
+  <div id="a-btn-container">
+    <button class="a-btn-2"></button>
+  </div>
+  <div>
+    <input type="button" class="an-input"></button>
+  </div>
+  <div id="an-input-container">
+    <input type="button" class="an-input-2"></button>
+  </div>
+
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { expect } from '@esm-bundle/chai';
+    import { sourceSelector } from '../../modules/dom.js';
+
+    runTests(async () => {
+      describe('dom#sourceSelector', () => {
+        it('sourceSelector - buttons', () => {
+          expect(sourceSelector(document.querySelector('#reject-all-handler'))).to.be.equal('#reject-all-handler');
+          expect(sourceSelector(document.querySelector('#accept-btn-handler'))).to.be.equal('#accept-btn-handler');
+
+          expect(sourceSelector(document.querySelector('.close-btn-handler'))).to.be.equal('#close-btn-container button');
+          expect(sourceSelector(document.querySelector('.orphan-btn-handler'))).to.be.equal('#test button.orphan-btn-handler');
+
+          expect(sourceSelector(document.querySelector('.cta-1'))).to.be.equal('#cta-container input');
+
+          expect(sourceSelector(document.querySelector('.orphan'))).to.be.equal('button.orphan');
+
+          expect(sourceSelector(document.querySelector('.a-btn'))).to.be.equal('button.a-btn');
+          expect(sourceSelector(document.querySelector('.a-btn-2'))).to.be.equal('#a-btn-container button');
+
+          expect(sourceSelector(document.querySelector('.an-input'))).to.be.equal('input.an-input');
+          expect(sourceSelector(document.querySelector('.an-input-2'))).to.be.equal('#an-input-container input');
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/test/unit/dom.sourceSelector.buttons.test.html
+++ b/test/unit/dom.sourceSelector.buttons.test.html
@@ -35,6 +35,16 @@
   <div id="an-input-container">
     <input type="button" class="an-input-2"></button>
   </div>
+  <div id="an-a-container">
+    <a href="page.html" class="cta"></a>
+  </div>
+  <div id="an-a-container-2">
+    <a href="page.html" class="button"></a>
+  </div>
+
+  <div class="with-classes a-block block" data-block-name="a-block">
+    <span class="cta">Button in a block</span>
+  </div>
 
   <script type="module">
     import { runTests } from '@web/test-runner-mocha';
@@ -59,6 +69,11 @@
 
           expect(sourceSelector(document.querySelector('.an-input'))).to.be.equal('input.an-input');
           expect(sourceSelector(document.querySelector('.an-input-2'))).to.be.equal('#an-input-container input');
+
+          expect(sourceSelector(document.querySelector('a.cta'))).to.be.equal('#an-a-container a');
+          expect(sourceSelector(document.querySelector('a.button'))).to.be.equal('#an-a-container-2 a');
+
+          expect(sourceSelector(document.querySelector('span.cta'))).to.be.equal('.a-block span.cta');
         });
       });
     });

--- a/test/unit/dom.sourceSelector.test.html
+++ b/test/unit/dom.sourceSelector.test.html
@@ -1,0 +1,57 @@
+<html>
+
+<head>
+  <title>Test Runner</title>
+</head>
+
+<body>
+  <a href="page.html" class="one">a link</a>
+  <div>a div</div>
+  <div class="with-one-class">a div</div>
+  <div class="with-classes another-class">another div</div>
+  <div class="multi-1" data-rum-source="has-priority">a div</div>
+  <div class="multi-2" id="multi-2" data-rum-source="has-priority-too">a div</div>
+  <div class="multi-3" id="id-has-priority">a div</div>
+
+  <form id="a-form">
+    <input type="text" class="a-text"></input>
+    <input type="checkbox" class="a-checkbox"></input>
+    <textarea class="a-textarea"></textarea>
+  </form>
+
+  <div class="with-classes a-block block" data-block-name="a-block">
+    <div id="a-div-in-block">a div</div>
+  </div>
+
+  
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { expect } from '@esm-bundle/chai';
+    import { sourceSelector } from '../../modules/dom.js';
+
+    runTests(async () => {
+      describe('dom#sourceSelector', () => {
+        it('sourceSelector - generic', () => {
+          expect(sourceSelector(document.querySelector('a.one'))).to.be.equal('a.one');
+          expect(sourceSelector(document.querySelector('body > div:first-of-type'))).to.be.equal('div');
+          expect(sourceSelector(document.querySelector('div.with-one-class'))).to.be.equal('div.with-one-class');
+          expect(sourceSelector(document.querySelector('div.with-classes'))).to.be.equal('div.with-classes');
+          expect(sourceSelector(document.querySelector('div.multi-1'))).to.be.equal('has-priority');
+          expect(sourceSelector(document.querySelector('div.multi-2'))).to.be.equal('has-priority-too');
+          expect(sourceSelector(document.querySelector('div.multi-3'))).to.be.equal('#id-has-priority');
+
+          expect(sourceSelector(document.querySelector('input[type="text"'))).to.be.equal('form input[type=\'text\']');
+          expect(sourceSelector(document.querySelector('input[type="checkbox"'))).to.be.equal('form input[type=\'checkbox\']');
+          expect(sourceSelector(document.querySelector('textarea'))).to.be.equal('form textarea');
+
+          expect(sourceSelector(document.querySelector('.a-block'))).to.be.equal('.a-block');
+          expect(sourceSelector(document.querySelector('#a-div-in-block'))).to.be.equal('.a-block #a-div-in-block');
+          
+          
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -108,46 +108,4 @@ describe('test dom#sourceSelector', () => {
     // eslint-disable-next-line no-unused-expressions
     expect(sourceSelector()).to.be.undefined;
   });
-
-  it('sourceSelector - select source when data-rum-source is set ', () => {
-    const div = document.createElement('div');
-    div.setAttribute('data-rum-source', 'test');
-    expect(sourceSelector(div)).to.be.equal('test');
-
-    // works also for nested elements
-    const span = document.createElement('span');
-    div.append(span);
-    expect(sourceSelector(span)).to.be.equal('test');
-  });
-
-  it('sourceSelector - select source for form and inputs', () => {
-    const form = document.createElement('form');
-    const input = document.createElement('input');
-    input.setAttribute('type', 'text');
-    form.append(input);
-    const textarea = document.createElement('textarea');
-    form.append(textarea);
-
-    expect(sourceSelector(input)).to.be.equal('form input[type=\'text\']');
-    expect(sourceSelector(textarea)).to.be.equal('form textarea');
-  });
-
-  it('sourceSelector - select source for block', () => {
-    const div = document.createElement('div');
-    div.classList.add('block');
-    div.setAttribute('data-block-name', 'test');
-    expect(sourceSelector(div)).to.be.equal('.test');
-  });
-
-  it('sourceSelector - select source for button', () => {
-    const button = document.createElement('button');
-    button.classList.add('button');
-    expect(sourceSelector(button)).to.be.equal('button.button');
-  });
-
-  it('sourceSelector - select source for cta', () => {
-    const div = document.createElement('div');
-    div.classList.add('cta');
-    expect(sourceSelector(div)).to.be.equal('div.cta');
-  });
 });

--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -142,12 +142,12 @@ describe('test dom#sourceSelector', () => {
   it('sourceSelector - select source for button', () => {
     const button = document.createElement('button');
     button.classList.add('button');
-    expect(sourceSelector(button)).to.be.equal('.button');
+    expect(sourceSelector(button)).to.be.equal('button.button');
   });
 
   it('sourceSelector - select source for cta', () => {
     const div = document.createElement('div');
     div.classList.add('cta');
-    expect(sourceSelector(div)).to.be.equal('.button');
+    expect(sourceSelector(div)).to.be.equal('div.cta');
   });
 });


### PR DESCRIPTION
Fix #204 by adding more logic to try to compute a selector to identify the (clicked) button. Probably not perfect but should at least cover the onetrust popup and some basic dom combo.