### PR TITLE
[React RUM] media observers

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,7 @@ module.exports = {
   rules: {
     'import/extensions': [2, 'ignorePackages'],
     'import/prefer-default-export': 0,
+    'no-underscore-dangle': ['error', { allow: ['_reactRootContainer'] }],
   },
   globals: {
     __rootdir: true,

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+npx lint-staged
 npm test

--- a/modules/index.js
+++ b/modules/index.js
@@ -346,8 +346,10 @@ function addTrackingFromConfig() {
     loadresource: () => addLoadResourceTracking(),
     utm: () => addUTMParametersTracking(),
     viewblock: () => addViewBlockTracking(window.document.body),
-    viewmedia: () => (isReactApp() ? addReactMediaTracking(window.document.body)
-      : addViewMediaTracking(window.document.body)),
+    viewmedia: () => {
+      addViewMediaTracking(window.document.body);
+      if (isReactApp()) addReactMediaTracking(window.document.body);
+    },
     consent: () => addCookieConsentTracking(),
     paid: () => addAdsParametersTracking(),
     email: () => addEmailParameterTracking(),

--- a/modules/index.js
+++ b/modules/index.js
@@ -222,10 +222,11 @@ function addReactMediaTracking(parent) {
       if (mutation.type === 'childList') {
         for (const node of mutation.addedNodes) {
           // improve performance by poking with querySelector first
-          if (node.querySelector && document.querySelector('img, video, audio, iframe')) {
+          if (node.querySelector && node.querySelector('img, video, audio, iframe')) {
             node?.querySelectorAll('img, video, audio, iframe')?.forEach((m) => {
               const element = m;
               if (!element.dataset.withObserver) {
+                // not so nice as we leave trace in the host's DOM
                 element.dataset.withObserver = 'true';
                 mediaobserver.observe(element);
               }

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -36,3 +36,25 @@ export const urlSanitizers = {
     return `${u.origin}${u.pathname}`;
   },
 };
+
+/**
+ * getReactContainers
+ * @param {DOMElement} container The DOM element to search for React containers
+ * @returns {Array} Array of DOM elements (if more than one) used to bootstrap React
+ */
+export const getReactContainers = (container) => container.querySelector('[data-reactroot], [data-reactid]')
+    || Array.from(container.querySelectorAll('*')).filter((e) => e._reactRootContainer !== undefined || Object.keys(e).some((k) => k.startsWith('__reactContainer')));
+
+/**
+ * Determines if the current page is running a React application
+ * by inspecting React-related elements in the DOM.
+ * @returns {bool}
+ */
+export const isReactApp = () => {
+  // https://gist.github.com/rambabusaravanan/1d594bd8d1c3153bc8367753b17d074b
+  if (!!window.React
+    || !!document.querySelector('[data-reactroot], [data-reactid]')
+    || Array.from(document.querySelectorAll('*')).some((e) => e._reactRootContainer !== undefined || Object.keys(e).some((k) => k.startsWith('__reactContainer')))
+  ) return true;
+  return false;
+};

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -42,8 +42,11 @@ export const urlSanitizers = {
  * @param {DOMElement} container The DOM element to search for React containers
  * @returns {Array} Array of DOM elements (if more than one) used to bootstrap React
  */
-export const getReactContainers = (container) => container.querySelector('[data-reactroot], [data-reactid]')
-    || Array.from(container.querySelectorAll('*')).filter((e) => e._reactRootContainer !== undefined || Object.keys(e).some((k) => k.startsWith('__reactContainer')));
+export const getReactContainers = (container) => {
+  const reactElement = container.querySelector('[data-reactroot], [data-reactid]');
+  if (reactElement) return [reactElement];
+  return Array.from(container.querySelectorAll('*')).filter((e) => e._reactRootContainer !== undefined || Object.keys(e).some((k) => k.startsWith('__reactContainer')));
+};
 
 /**
  * Determines if the current page is running a React application

--- a/test/it/img.react.test.html
+++ b/test/it/img.react.test.html
@@ -20,7 +20,6 @@
             rum: {
               sampleRUM: (checkpoint, data) => {
                 called = true;
-                console.log(checkpoint)
                 if (checkpoint === 'viewmedia') {
                   imagesSeen.push(data.target);
                   console.log('viewmedia', data.target);
@@ -41,18 +40,16 @@
           });
 
           await new Promise((resolve) => {
-            setTimeout(resolve, 900);
+            setTimeout(resolve, 700); //webkit friendly delay
           });
-
           expect(called).to.be.true;
           expect(imagesSeen).to.deep.equal(['https://www.example.com/loadstart.jpg']);
 
           reactDiv.innerHTML = '<div><img src="https://www.example.com/loadlater.jpg" alt="example image"></div>';
 
           await new Promise((resolve) => {
-            setTimeout(resolve, 900);
+            setTimeout(resolve, 700); //webkit friendly delay
           });
-
           expect(called).to.be.true;
           expect(imagesSeen).to.deep.equal(['https://www.example.com/loadstart.jpg','https://www.example.com/loadlater.jpg']);
         });

--- a/test/it/img.react.test.html
+++ b/test/it/img.react.test.html
@@ -1,0 +1,69 @@
+<html>
+
+<head>
+  <title>Test Runner</title>
+</head>
+
+<body>
+  <script type="module">
+    window.React = {};
+    import { runTests } from '@web/test-runner-mocha';
+    import { expect } from '@esm-bundle/chai';
+
+    runTests(async () => {
+      describe('HTML IMG React Tests', () => {
+
+        it('rum enhancer reports image, even if added later', async () => {
+          let called = false;
+          const imagesSeen = [];
+          window.hlx = {
+            rum: {
+              sampleRUM: (checkpoint, data) => {
+                called = true;
+                console.log(checkpoint)
+                if (checkpoint === 'viewmedia') {
+                  imagesSeen.push(data.target);
+                  console.log('viewmedia', data.target);
+                }
+              }
+            }
+          };
+
+          const script = document.createElement('script');
+          script.src = new URL('/modules/index.js', window.location).href;
+          script.type = 'module';
+          document.head.appendChild(script);
+
+          const reactDiv = document.getElementById('react');
+
+          await new Promise((resolve) => {
+            script.onload = resolve;
+          });
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 900);
+          });
+
+          expect(called).to.be.true;
+          expect(imagesSeen).to.deep.equal(['https://www.example.com/loadstart.jpg']);
+
+          reactDiv.innerHTML = '<div><img src="https://www.example.com/loadlater.jpg" alt="example image"></div>';
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 900);
+          });
+
+          expect(called).to.be.true;
+          expect(imagesSeen).to.deep.equal(['https://www.example.com/loadstart.jpg','https://www.example.com/loadlater.jpg']);
+        });
+
+      });
+    });
+  </script>
+  <div id="react" data-reactroot="yes">
+    <img src="https://www.example.com/loadstart.jpg" alt="example image">
+   </div>
+  
+</body>
+
+</html>


### PR DESCRIPTION
 The current implementation only captures media mutations in a data-block.
 This implementation adds a generic media observer for React containers.

Notes:
- This was a bit rushed and lacks more thought, however it could be useful for discussion purposes.
- When trying to solve the question of "when is react finished loading" i have not found a generic solution that does not require some kind of implementation on the react side, hence the observers on the react container
- I think that the proposed solution, depending on the size of the react app, can have performance impacts on the host app and should be tested a bit more in depth. 
- another idea could involve using setTimeouts (or something in a polling method) instead, which would be less precise but less impactful performance wise
- Is the current implementation of data-block only going to change? If so, we might want to have a generic solution that solves both problems.

