### PR TITLE
fix(paid): new hostname added to paid checkpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const fflags = {
   enabled: (flag, callback) => fflags.has(flag) && callback(),
   disabled: (flag, callback) => !fflags.has(flag) && callback(),
   onetrust: [543, 770, 1136],
-  ads: [1139, 543, 770, 984],
+  ads: [1139, 543, 770, 984, 955],
   email: [1139, 543, 770, 984],
 };
 


### PR DESCRIPTION
This PR adds a new domain to the `ads` feature flags - which is used to collect `paid` checkpoint.

If [this PR](https://github.com/adobe/helix-rum-enhancer/pull/214) is merged, then there is no need to merge this one.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
