### PR TITLE
feat: acquisition checkpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -261,9 +261,7 @@ fflags.enabled('onetrust', () => {
 
   const knownAdNetworksSection = matchParams(adNetworks, searchParams).map((network) => `paid=${network}`);
   const knownEmailNetworksSection = matchParams(emailNetworks, searchParams).map((network) => `email=${network}`);
-  const utmSection = searchParams.filter(([key]) => key.startsWith('utm_'))
-    .filter(([key]) => key !== 'utm_id')
-    .filter(([key]) => key !== 'utm_term')
+  const utmSection = searchParams.filter(([key]) => ['utm_medium', 'utm_source'].includes(key))
     .map(([key, value]) => `${key}=${value}`);
 
   const target = [knownAdNetworksSection, knownEmailNetworksSection, utmSection].join('&');

--- a/src/index.js
+++ b/src/index.js
@@ -244,7 +244,7 @@ fflags.enabled('onetrust', () => {
   const target = {
     utm_source: usp.get('utm_source'),
     utm_medium: usp.get('utm_medium'),
-    others: [...usp.keys()].filter((k) => !/utm_([ms])/.test(k)),
+    others: [...usp.keys()].filter((k) => !/^utm_/.test(k)),
   };
   sampleRUM('acquisition', { source: document.referrer, target: JSON.stringify(target) });
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -239,44 +239,12 @@ fflags.enabled('onetrust', () => {
   }
 });
 
-sampleRUM.paidNetworks = {
-  google: /gclid|gclsrc|wbraid|gbraid/,
-  doubleclick: /dclid/,
-  microsoft: /msclkid/,
-  facebook: /fb(cl|ad_|pxl_)id/,
-  twitter: /tw(clid|src|term)/,
-  linkedin: /li_fat_id/,
-  pinterest: /epik/,
-  tiktok: /ttclid/,
-};
-
-// paid checkpoint
-(() => {
-  const params = Array.from(new URLSearchParams(window.location.search).keys());
-  Object.entries(sampleRUM.paidNetworks).forEach(([network, regex]) => {
-    params.filter((param) => regex.test(param)).forEach((param) => sampleRUM('paid', { source: network, target: param }));
-  });
-})();
-
-sampleRUM.emailProviders = {
-  mailchimp: /mc_(c|e)id/,
-  marketo: /mkt_tok/,
-};
-
-// email checkpoint
-(() => {
-  const params = Array.from(new URLSearchParams(window.location.search).keys());
-  Object.entries(sampleRUM.emailProviders).forEach(([network, regex]) => {
-    params.filter((param) => regex.test(param)).forEach((param) => sampleRUM('email', { source: network, target: param }));
-  });
-})();
-
 (() => {
   const nonPIITrackingParams = [
-    ...Object.values(sampleRUM.paidNetworks),
-    ...Object.values(sampleRUM.emailProviders),
-    /utm_(source|medium)/,
-  ];
+    /gclid|gclsrc|wbraid|gbraid|dclid|msclkid|fb(cl|ad_|pxl_)id|tw(clid|src|term)|li_fat_id|epik|ttclid/,
+    /mc_([ce])id|mkt_tok/,
+    /utm_(source|medium)/];
+
   const target = [...new URLSearchParams(window.location.search)]
     .filter(([key]) => nonPIITrackingParams.find((regex) => regex.test(key)))
     .map(([key, value]) => `${key}=${value}`)

--- a/src/index.js
+++ b/src/index.js
@@ -240,14 +240,11 @@ fflags.enabled('onetrust', () => {
 });
 
 (() => {
-  const nonPIITrackingParams = [
-    /gclid|gclsrc|wbraid|gbraid|dclid|msclkid|fb(cl|ad_|pxl_)id|tw(clid|src|term)|li_fat_id|epik|ttclid/,
-    /mc_([ce])id|mkt_tok/,
-    /utm_(source|medium)/];
-
-  const target = [...new URLSearchParams(window.location.search)]
-    .filter(([key]) => nonPIITrackingParams.find((regex) => regex.test(key)))
-    .map(([key, value]) => `${key}=${value}`)
-    .join('&');
-  sampleRUM('acquisition', { source: document.referrer, target });
+  const usp = new URLSearchParams(window.location.search);
+  const target = {
+    utm_source: usp.get('utm_source'),
+    utm_medium: usp.get('utm_medium'),
+    others: [...usp.keys()].filter((k) => !/utm_([ms])/.test(k)),
+  };
+  sampleRUM('acquisition', { source: document.referrer, target: JSON.stringify(target) });
 })();

--- a/src/index.js
+++ b/src/index.js
@@ -198,6 +198,14 @@ new PerformanceObserver((list) => {
     });
 }).observe({ type: 'resource', buffered: true });
 
+[...new URLSearchParams(window.location.search).entries()]
+  .filter(([key]) => key.startsWith('utm_'))
+  .filter(([key]) => key !== 'utm_id')
+  .filter(([key]) => key !== 'utm_term')
+  .forEach(([key, value]) => {
+    sampleRUM('utm', { source: key, target: value });
+  });
+
 fflags.enabled('onetrust', () => {
   const cmpCookie = document.cookie.split(';')
     .map((c) => c.trim())
@@ -232,17 +240,9 @@ fflags.enabled('onetrust', () => {
   }
 });
 
-// acquisition checkpoint
+// paid checkpoint
 (() => {
-  const matchParams = (networks, params) => {
-    const match = params.filter(([key]) => Object.values(networks).some((regex) => regex.test(key)))
-      .map(([key]) => Object.keys(networks).find((network) => networks[network].test(key)));
-    return [...new Set(match)];
-  };
-
-  const searchParams = [...new URLSearchParams(window.location.search).entries()];
-
-  const adNetworks = {
+  const networks = {
     google: /gclid|gclsrc|wbraid|gbraid/,
     doubleclick: /dclid/,
     microsoft: /msclkid/,
@@ -252,19 +252,20 @@ fflags.enabled('onetrust', () => {
     pinterest: /epik/,
     tiktok: /ttclid/,
   };
+  const params = Array.from(new URLSearchParams(window.location.search).keys());
+  Object.entries(networks).forEach(([network, regex]) => {
+    params.filter((param) => regex.test(param)).forEach((param) => sampleRUM('paid', { source: network, target: param }));
+  });
+})();
 
-  const emailNetworks = {
+fflags.enabled('email', () => {
+  const networks = {
     mailchimp: /mc_(c|e)id/,
     marketo: /mkt_tok/,
 
   };
-
-  const knownAdNetworksSection = matchParams(adNetworks, searchParams).map((network) => `paid=${network}`);
-  const knownEmailNetworksSection = matchParams(emailNetworks, searchParams).map((network) => `email=${network}`);
-  const utmSection = searchParams.filter(([key]) => ['utm_medium', 'utm_source'].includes(key))
-    .map(([key, value]) => `${key}=${value}`);
-
-  const target = [knownAdNetworksSection, knownEmailNetworksSection, utmSection].join('&');
-
-  sampleRUM('acquisition', { source: document.referrer, target });
-})();
+  const params = Array.from(new URLSearchParams(window.location.search).keys());
+  Object.entries(networks).forEach(([network, regex]) => {
+    params.filter((param) => regex.test(param)).forEach((param) => sampleRUM('email', { source: network, target: param }));
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -240,11 +240,12 @@ fflags.enabled('onetrust', () => {
 });
 
 (() => {
+  const tracking = /gclid|gclsrc|wbraid|gbraid|dclid|msclkid|fb(cl|ad_|pxl_)id|tw(clid|src|term)|li_fat_id|epik|ttclid|mc_([ce])id|mkt_tok|srsltid/;
   const usp = new URLSearchParams(window.location.search);
   const target = {
     utm_source: usp.get('utm_source'),
     utm_medium: usp.get('utm_medium'),
-    others: [...usp.keys()].filter((k) => !/^utm_/.test(k)),
+    others: [...usp.keys()].filter((k) => tracking.test(k)),
   };
-  sampleRUM('acquisition', { source: document.referrer, target: JSON.stringify(target) });
+  sampleRUM('acquisition', { source: document.referrer, target });
 })();

--- a/test/acquisition/acquisition-empty.test.html
+++ b/test/acquisition/acquisition-empty.test.html
@@ -37,7 +37,7 @@
 
         const expectedAcquisition = {
           source: '',
-          target: '{"utm_source":null,"utm_medium":null,"others":[]}'
+          target: {"utm_source":null,"utm_medium":null,"others":[]}
         }
 
         expect(acquisition).to.eql(expectedAcquisition);

--- a/test/acquisition/acquisition-empty.test.html
+++ b/test/acquisition/acquisition-empty.test.html
@@ -1,0 +1,50 @@
+<html>
+
+<head>
+  <title>Test Runner</title>
+</head>
+
+<body>
+<script type="module">
+  import { runTests } from '@web/test-runner-mocha';
+  import { expect } from '@esm-bundle/chai';
+
+  runTests(async () => {
+    describe('Acquisition checkpoint with empty params', () => {
+
+      it('no referrer and query params', async () => {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('wtr-session-id');
+        history.replaceState(null, '', url.href);
+
+        let acquisition;
+
+        window.hlx = { rum: {} };
+        window.hlx.rum.sampleRUM = (checkpoint, data) => {
+          if (checkpoint === 'acquisition') {
+            acquisition = data;
+          }
+        }
+        window.hlx.rum.sampleRUM.drain = () => {};
+
+        const script = document.createElement('script');
+        script.src = new URL('/src/index.js', window.location).href;
+        document.head.appendChild(script);
+
+        await new Promise((resolve) => {
+          script.onload = resolve;
+        });
+
+        const expectedAcquisition = {
+          source: '',
+          target: '{"utm_source":null,"utm_medium":null,"others":[]}'
+        }
+
+        expect(acquisition).to.eql(expectedAcquisition);
+      });
+    });
+  });
+</script>
+</body>
+
+</html>

--- a/test/acquisition/acquisition-full.test.html
+++ b/test/acquisition/acquisition-full.test.html
@@ -54,7 +54,7 @@
 
         const expectedAcquisition = {
           source: 'https://some-referrer.com/',
-          target: '{"utm_source":"some-utm-source","utm_medium":"some-utm-medium","others":["gclid","not_interesting_param"]}'
+          target: {utm_source:'some-utm-source',utm_medium:'some-utm-medium',others:['gclid']}
         }
 
         expect(acquisition).to.eql(expectedAcquisition);

--- a/test/acquisition/acquisition-full.test.html
+++ b/test/acquisition/acquisition-full.test.html
@@ -1,0 +1,66 @@
+<html>
+
+<head>
+  <title>Test Runner</title>
+</head>
+
+<body>
+<script type="module">
+  import { runTests } from '@web/test-runner-mocha';
+  import { expect } from '@esm-bundle/chai';
+
+  runTests(async () => {
+    describe('Acquisition checkpoint with params', () => {
+
+      const setQueryParams = ( params ) => {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('wtr-session-id');
+        Object.entries(params).forEach(([key, value]) => {
+          url.searchParams.set(key, value);
+        })
+        history.replaceState(null, '', url.href);
+      }
+
+      it('with referrer and query params', async () => {
+        setQueryParams({
+          utm_medium: 'some-utm-medium',
+          utm_source: 'some-utm-source',
+          gclid: 'some-google-id',
+          not_interesting_param: 'some-value'
+        })
+        Object.defineProperty(document, 'referrer', {
+          value: 'https://some-referrer.com/',
+          configurable: true
+        });
+
+        let acquisition;
+
+        window.hlx = { rum: {} };
+        window.hlx.rum.sampleRUM = (checkpoint, data) => {
+          if (checkpoint === 'acquisition') {
+            acquisition = data;
+          }
+        }
+        window.hlx.rum.sampleRUM.drain = () => {};
+
+        const script = document.createElement('script');
+        script.src = new URL('/src/index.js', window.location).href;
+        document.head.appendChild(script);
+
+        await new Promise((resolve) => {
+          script.onload = resolve;
+        });
+
+        const expectedAcquisition = {
+          source: 'https://some-referrer.com/',
+          target: '{"utm_source":"some-utm-source","utm_medium":"some-utm-medium","others":["gclid","not_interesting_param"]}'
+        }
+
+        expect(acquisition).to.eql(expectedAcquisition);
+      });
+    });
+  });
+</script>
+</body>
+
+</html>

--- a/test/acquisition/acquisition-full.test.html
+++ b/test/acquisition/acquisition-full.test.html
@@ -23,6 +23,7 @@
 
       it('with referrer and query params', async () => {
         setQueryParams({
+          utm_id: 'some-pii-utm-id',
           utm_medium: 'some-utm-medium',
           utm_source: 'some-utm-source',
           gclid: 'some-google-id',


### PR DESCRIPTION
This approach combines `utm` , `paid`, and `email` into one checkpoint = `acquisition`. Uses `document.referrer` as `source`, and the combined value as `target`:

example from real use-case

```
checkpoint=acquisition
source=https://www.youtube.com/
target={ utm_medium: 'youtube', utm_source: 'video', others: ['gclid'] }
```

`referrer` and `query params` collected are being processed by rum-collector via https://github.com/adobe/helix-rum-collector/pull/358

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
