### PR TITLE
fix(navigation): remove `leave` checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ It will add following new checkpoints:
 - `viewmedia`: An image or video hosted by Helix Media Bus has been scrolled into the viewport
 - `reload`, `navigate`, `enter`: depending on how the current page was accessed
 - `formsubmit`: when a form is submitted
-- `leave`: when the user leaves the page
 
 ## Development
 

--- a/modules/defaults.js
+++ b/modules/defaults.js
@@ -12,5 +12,5 @@
 import { fflags } from './fflags.js';
 
 export const KNOWN_PROPERTIES = ['weight', 'id', 'referer', 'checkpoint', 't', 'source', 'target', 'cwv', 'CLS', 'FID', 'LCP', 'INP', 'TTFB'];
-export const DEFAULT_TRACKING_EVENTS = ['click', 'cwv', 'form', 'enterleave', 'viewblock', 'viewmedia', 'loadresource', 'utm', 'paid', 'email', 'consent'];
+export const DEFAULT_TRACKING_EVENTS = ['click', 'cwv', 'form', 'viewblock', 'viewmedia', 'loadresource', 'utm', 'paid', 'email', 'consent'];
 fflags.enabled('example', () => DEFAULT_TRACKING_EVENTS.push('example'));

--- a/modules/index.js
+++ b/modules/index.js
@@ -103,7 +103,7 @@ function addCWVTracking() {
   }, 2000); // wait for delayed
 }
 
-function addEnterLeaveTracking() {
+function addNavigationTracking() {
   // enter checkpoint when referrer is not the current page url
   const navigate = (source, type) => {
     const payload = { source, target: document.visibilityState };
@@ -122,16 +122,6 @@ function addEnterLeaveTracking() {
   new PerformanceObserver((list) => list
     .getEntries().map((entry) => navigate(window.hlx.referrer || document.referrer, entry.type)))
     .observe({ type: 'navigation', buffered: true });
-
-  const leave = ((event) => {
-    if (leave.left || (event.type === 'visibilitychange' && document.visibilityState !== 'hidden')) {
-      return;
-    }
-    leave.left = true;
-    sampleRUM('leave');
-  });
-  window.addEventListener('visibilitychange', ((event) => leave(event)));
-  window.addEventListener('pagehide', ((event) => leave(event)));
 }
 
 function addLoadResourceTracking() {
@@ -234,7 +224,7 @@ function addTrackingFromConfig() {
   });
   addCWVTracking();
   addFormTracking(window.document.body);
-  addEnterLeaveTracking();
+  addNavigationTracking();
   addLoadResourceTracking();
   addUTMParametersTracking(sampleRUM);
   addViewBlockTracking(window.document.body);

--- a/test/it/navigation.test.html
+++ b/test/it/navigation.test.html
@@ -72,16 +72,11 @@
             setTimeout(resolve, 1000);
           });
 
-          // pretend to leave the page
-          window.dispatchEvent(new Event('pagehide'));
-          window.dispatchEvent(new Event('pagehide'));
-
-          expect(called).to.have.lengthOf(5);
+          expect(called).to.have.lengthOf(4);
           expect(called[0][0]).to.equal('navigate');
           expect(called[1][0]).to.equal('reload');
           expect(called[2][0]).to.equal('back_forward');
           expect(called[3][0]).to.equal('prerender');
-          expect(called[4][0]).to.equal('leave');
         });
 
       });


### PR DESCRIPTION
as requested in https://github.com/adobe/helix-rum-enhancer/pull/257#discussion_r1718152824 the `leave` checkpoint
is no longer processed by the rum collector, so we can do without it. This reverts https://github.com/adobe/helix-rum-enhancer/commit/33abd03947b0345200eea1d5857b72a036c09923
