### PR TITLE
feat(checkpoints): add support for the `language` checkpoint

### DIFF
--- a/modules/fflags.js
+++ b/modules/fflags.js
@@ -19,4 +19,5 @@ export const fflags = {
   disabled: (flag, callback) => !fflags.has(flag) && callback(),
   eagercwv: [683],
   example: [543, 770, 1136],
+  language: [543, 959, 1139, 620],
 };

--- a/modules/index.js
+++ b/modules/index.js
@@ -267,6 +267,11 @@ function addTrackingFromConfig() {
   addCookieConsentTracking(sampleRUM);
   addAdsParametersTracking(sampleRUM);
   addEmailParameterTracking(sampleRUM);
+  fflags.enabled('language', () => {
+    const target = navigator.language;
+    const source = document.documentElement.lang;
+    sampleRUM('language', { source, target });
+  });
 }
 
 function initEnhancer() {

--- a/test/it/index.test.html
+++ b/test/it/index.test.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en-NZ">
 
 <head>
   <title>Test Runner</title>
@@ -40,9 +40,17 @@
           // click anywhere
           await sendMouse({ type: 'click', position: [10, 10] });
 
-          expect(called).to.have.lengthOf(2);
-          expect(called[0][0]).to.equal('enter');
-          expect(called[1][0]).to.equal('click');
+          // the order is not stable across browsers, so we
+          // sort called by the first argument
+          called.sort((a, b) => a[0].localeCompare(b[0]));
+
+          expect(called).to.have.lengthOf(3);
+          expect(called[0][0]).to.equal('click');
+
+          expect(called[1][0]).to.equal('enter');
+
+          expect(called[2][0]).to.equal('language');
+          expect(called[2][1].source).to.equal('en-NZ');
         });
 
       });

--- a/test/it/navigation.test.html
+++ b/test/it/navigation.test.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en_IE">
 
 <head>
   <title>Test Runner</title>
@@ -68,7 +68,7 @@
             setTimeout(resolve, 1000);
           });
 
-          expect(called).to.have.lengthOf(4);
+          expect(called).to.have.lengthOf(5);
           expect(called[0][0]).to.equal('navigate');
           expect(called[1][0]).to.equal('reload');
           expect(called[2][0]).to.equal('back_forward');


### PR DESCRIPTION
source being the lang attribute of the html and target being navigator.language

see https://cq-dev.slack.com/archives/C07198KKQ07/p1725350425871959 depends on https://github.com/adobe/helix-rum-collector/pull/387
