### PR TITLE
feat: handle pre-speculation rules and rendering

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -25,13 +25,15 @@ import { fflags } from './fflags.js';
 const { sampleRUM, queue, isSelected } = (window.hlx && window.hlx.rum) ? window.hlx.rum
   /* c8 ignore next */ : {};
 
+// blocks mutation observer
 // eslint-disable-next-line no-use-before-define, max-len
 const blocksMO = window.MutationObserver ? new MutationObserver(blocksMCB)
-  /* c8 ignore next */ : {}; // blocks mutation observer
+  /* c8 ignore next */ : {};
 
+// media mutation observer
 // eslint-disable-next-line no-use-before-define, max-len
 const mediaMO = window.MutationObserver ? new MutationObserver(mediaMCB)
-  /* c8 ignore next */ : {}; // media mutation observer
+  /* c8 ignore next */ : {};
 
 function trackCheckpoint(checkpoint, data, t) {
   const { weight, id } = window.hlx.rum;

--- a/modules/index.js
+++ b/modules/index.js
@@ -112,9 +112,21 @@ function addCWVTracking() {
 function addNavigationTracking() {
   // enter checkpoint when referrer is not the current page url
   const navigate = (source, type, redirectCount) => {
+    // target can be 'visible', 'hidden' (background tab) or 'prerendered' (speculation rules)
     const payload = { source, target: document.visibilityState };
-    // reload: same page, navigate: same origin, enter: everything else
-    if (type === 'reload' || source === window.location.href) {
+    if (document.prerendering) {
+      // listen for "activation" of the current pre-rendered page
+      document.addEventListener('prerenderingchange', () => {
+        // pre-rendered page is now "activated"
+        payload.target = 'prerendered';
+        sampleRUM('navigate', payload); // prerendered navigation
+      }, {
+        once: true,
+      });
+      if (type === 'navigate') {
+        sampleRUM('prerender', payload); // prerendering page
+      }
+    } else if (type === 'reload' || source === window.location.href) {
       sampleRUM('reload', payload);
     } else if (type && type !== 'navigate') {
       sampleRUM(type, payload); // back, forward, prerender, etc.

--- a/modules/index.js
+++ b/modules/index.js
@@ -112,6 +112,8 @@ function addNavigationTracking() {
   const navigate = (source, type, redirectCount) => {
     // target can be 'visible', 'hidden' (background tab) or 'prerendered' (speculation rules)
     const payload = { source, target: document.visibilityState };
+    /* c8 ignore next 13 */
+    // prerendering cannot be tested yet with headless browsers
     if (document.prerendering) {
       // listen for "activation" of the current pre-rendered page
       document.addEventListener('prerenderingchange', () => {

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -23,7 +23,6 @@ export default {
       'test/fixtures/**',
       'node_modules/**',
       '.rum/**',
-      'src/**',
     ],
   },
   files: [

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -23,6 +23,7 @@ export default {
       'test/fixtures/**',
       'node_modules/**',
       '.rum/**',
+      'src/**',
     ],
   },
   files: [


### PR DESCRIPTION
Address the collection part of https://github.com/adobe/aem-lib/issues/101
Will then require Explorer adjustments.

This PR only changes the current behaviour for the pre-rendered pages:
- fires a `prerender` checkpoint when a page is pre-rendered by the speculation engines - target will always be `hidden`
- fires a `navigate` checkpoint with `target=prerendered` when page is "activated".

`navigate` will then have 3 possible targets:
1. `visible`- default navigation
2. `hidden` - background tab
3. `prerendered` - pre-rendered pages