### PR TITLE
chore: renovate PR on dev dep do not trigger psi check

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -5,5 +5,12 @@
   "baseBranches": [
     "main",
     "1.x"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "label": "ignore-psi-check", 
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Use new helix-bot capability (see https://github.com/adobe/helix-bot/issues/1573) to ignore psi check if renovate makes a PR on dev dependency.
