### PR TITLE
fix: do not process duplicate navigation checkpoints

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -147,16 +147,16 @@ function addNavigationTracking() {
 
   const processed = new Set(); // avoid processing duplicate types
   new PerformanceObserver((list) => list
-  .getEntries().filter(({type}) => !processed.has(type))
-  .map((e) => {
-    navigate(
-      window.hlx.referrer || document.referrer,
-      e.type,
-      e.redirectCount,
-    );
-    processed.add(e.type);
-  });
-}).observe({ type: 'navigation', buffered: true });
+    .getEntries()
+    .filter(({ type }) => !processed.has(type))
+    .forEach((e) => {
+      navigate(
+        window.hlx.referrer || document.referrer,
+        e.type,
+        e.redirectCount,
+      );
+      processed.add(e.type);
+    })).observe({ type: 'navigation', buffered: true });
 }
 
 function addLoadResourceTracking() {

--- a/modules/index.js
+++ b/modules/index.js
@@ -145,13 +145,18 @@ function addNavigationTracking() {
     });
   };
 
+  const processed = new Set(); // avoid processing duplicate types
   new PerformanceObserver((list) => list
-    .getEntries().map((e) => navigate(
-      window.hlx.referrer || document.referrer,
-      e.type,
-      e.redirectCount,
-    )))
-    .observe({ type: 'navigation', buffered: true });
+    .getEntries().forEach((e) => {
+      if (!processed.has(e.type)) {
+        navigate(
+          window.hlx.referrer || document.referrer,
+          e.type,
+          e.redirectCount,
+        );
+        processed.add(e.type);
+      }
+    })).observe({ type: 'navigation', buffered: true });
 }
 
 function addLoadResourceTracking() {

--- a/modules/index.js
+++ b/modules/index.js
@@ -147,16 +147,16 @@ function addNavigationTracking() {
 
   const processed = new Set(); // avoid processing duplicate types
   new PerformanceObserver((list) => list
-    .getEntries().forEach((e) => {
-      if (!processed.has(e.type)) {
-        navigate(
-          window.hlx.referrer || document.referrer,
-          e.type,
-          e.redirectCount,
-        );
-        processed.add(e.type);
-      }
-    })).observe({ type: 'navigation', buffered: true });
+  .getEntries().filter(({type}) => !processed.has(type))
+  .map((e) => {
+    navigate(
+      window.hlx.referrer || document.referrer,
+      e.type,
+      e.redirectCount,
+    );
+    processed.add(e.type);
+  });
+}).observe({ type: 'navigation', buffered: true });
 }
 
 function addLoadResourceTracking() {

--- a/modules/index.js
+++ b/modules/index.js
@@ -149,14 +149,12 @@ function addNavigationTracking() {
   new PerformanceObserver((list) => list
     .getEntries()
     .filter(({ type }) => !processed.has(type))
-    .forEach((e) => {
-      navigate(
-        window.hlx.referrer || document.referrer,
-        e.type,
-        e.redirectCount,
-      );
-      processed.add(e.type);
-    })).observe({ type: 'navigation', buffered: true });
+    .map((e) => [e, processed.add(e.type)])
+    .map(([e]) => navigate(
+      window.hlx.referrer || document.referrer,
+      e.type,
+      e.redirectCount,
+    ))).observe({ type: 'navigation', buffered: true });
 }
 
 function addLoadResourceTracking() {

--- a/test/it/navigation.enter.test.html
+++ b/test/it/navigation.enter.test.html
@@ -43,9 +43,9 @@
     import { assert, expect} from '@esm-bundle/chai';
 
     runTests(async () => {
-      describe('Test Resource Loading', () => {
+      describe('Test Enter Navigation', () => {
 
-        it('Can track missing resources', async function test() {
+        it('Can track a single enter navigation checkpoint', async function test() {
           await new Promise((resolve) => {
             setTimeout(resolve, 3000);
           });

--- a/test/it/navigation.enter.test.html
+++ b/test/it/navigation.enter.test.html
@@ -1,0 +1,60 @@
+<html>
+
+<head>
+  <title>Test Runner</title>
+  <script>
+    // we load from localhost, and have the ability to
+    // change the scripts that are being served. Check the
+    // web-test-runner.config.js file for details
+    window.RUM_BASE = window.origin;
+    // we log what's being sent to the "server"
+    window.called = [];
+
+    const navigation = ['enter', 'reload', 'redirect', 'prerender'];
+    // and navigator.sendBeacon has been replaced with
+    // a call to fakeSendBeacon
+    window.fakeSendBeacon = function (url, payload) {
+      // if payload is a string, we assume it's a JSON string
+      if (typeof payload === 'string') {
+        const data = JSON.parse(payload);
+        if (navigation.includes(data.checkpoint)) {
+          window.called.push(data);
+        }
+      } else {
+        // it's a blob
+        payload.text().then((text) => {
+          const data = JSON.parse(text);
+          if (navigation.includes(data.checkpoint)) {
+            window.called.push(data);
+          }
+        });
+      }
+    };
+  </script>
+  <script defer type="text/javascript" src="/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+</head>
+
+<body>
+  <div class="block" data-block-status="loaded">
+    The first block
+  </div>
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { assert, expect} from '@esm-bundle/chai';
+
+    runTests(async () => {
+      describe('Test Resource Loading', () => {
+
+        it('Can track missing resources', async function test() {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 3000);
+          });
+
+          console.log('window.called', window.called);
+          expect(window.called).to.have.lengthOf(1, 'one navigation event');
+          expect(window.called[0].checkpoint).to.equal('enter');
+        });
+      });
+    });
+  </script>
+</body>


### PR DESCRIPTION
We observe bundles with multiple `enter` and `reload` checkpoints. While this does not seem to be critical, it is not necessary to post them twice.

Background: for unknown reason, the PerformanceObserver captures the events twice. The buffering seems to be the root cause but disabling the buffering might lead to losing some of the events.