### PR TITLE
Feat:  Enhance click checkpoint to cover focus events

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -248,11 +248,21 @@ function addViewMediaTracking(parent) {
   }
 }
 
+function addFocusTracking(parent) {
+  parent.addEventListener('focusin', (event) => {
+    if (['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'].includes(event.target.tagName)
+      || event.target.getAttribute('contenteditable') === 'true') {
+      sampleRUM('click', { source: sourceSelector(event.target) });
+    }
+  });
+}
+
 function addFormTracking(parent) {
   activateBlocksMO();
   activateMediaMO();
   parent.querySelectorAll('form').forEach((form) => {
     form.addEventListener('submit', (e) => sampleRUM('formsubmit', { target: targetSelector(e.target), source: sourceSelector(e.target) }), { once: true });
+    addFocusTracking(form);
   });
 }
 

--- a/test/it/focus.test.html
+++ b/test/it/focus.test.html
@@ -21,10 +21,15 @@
       } else {
         // it's a blob
         payload.text().then((text) => {
-          console.log(JSON.parse(text));
           window.called.push(JSON.parse(text));
         });
       }
+    };
+
+    window.wait = async function (ms) {
+      return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+      });
     };
   </script>
   <script defer type="text/javascript" src="/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
@@ -38,12 +43,19 @@
   <div id="focusable-element" tabindex="0">
     Focusable element
   </div>
+  <div id="editable-element-outside-form" contenteditable="true">
+    Editable element outside form
+  </div>
+  <input type="text" id="field-outside-form" name="field-outside-form" />
   <form action="javascript:false;" method="POST">
     <input type="text" name="name" value="John Doe">
     <input type="email" name="email" value="JohnDoe@example.com">
-    <input type="submit" value="Submit">
+    <button type="submit">Submit</button>
     <div id="focusable-element-inside-form" tabindex="0">
       Focusable element inside form
+    </div>
+    <div id="editable-element-inside-form" contenteditable="true">
+      Editable element inside form
     </div>
   </form>
   <script type="module">
@@ -57,75 +69,63 @@
           window.called = [];
         });
 
-        it('Can observe focus on form fields', async () => {
+        it('can observe focus on form fields', async () => {
           const form = document.querySelector('form');
+          // wait for the adding focus event tracking
+          await window.wait(2000);
 
           form.querySelector('input[type="text"]').focus();
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 0);
-          });
+          await window.wait(100);
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-          });
           assert(window.called.some((call) => call.checkpoint === 'click'), 'click checkpoint missing');
         });
 
-        it('Can not observe focus on focusable elements', async () => {
+        it('can not observe focus on elements outside of a form', async () => {
           const focusableElement = document.querySelector('#focusable-element');
-
           focusableElement.focus();
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 0);
-          });
+          await window.wait(100);
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-          });
-          assert(window.called.every((call) => call.checkpoint !== 'click'), 'click checkpoint missing');
+          assert(window.called.every((call) => call.checkpoint !== 'click'), 'click checkpoint is present');
         });
 
-        it('Can observe focus when tabbing between form fields', async () => {
-          const form = document.querySelector('form');
-          const textInput = form.querySelector('input[type="text"]');
-          const emailInput = form.querySelector('input[type="email"]');
+        it('can not observe focus on elements outside of a form', async () => {
+          const fieldOutsideForm = document.querySelector('#field-outside-form');
+          fieldOutsideForm.focus();
 
-          // Focus the text input first
-          textInput.focus();
+          await window.wait(100);
 
-          // Simulate tab key by focusing the next element
-          const tabEvent = new KeyboardEvent('keydown', {
-            key: 'Tab',
-            code: 'Tab',
-            bubbles: true,
-            cancelable: true
-          });
-          textInput.dispatchEvent(tabEvent);
+          const editableElementOutsideForm = document.querySelector('#editable-element-outside-form');
+          editableElementOutsideForm.focus();
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-          });
+          await window.wait(100);
 
-          assert(window.called.some((call) => call.checkpoint === 'click'), 'click checkpoint missing');
+          assert(window.called.every((call) => call.checkpoint !== 'click'), 'click checkpoint is present');
         });
 
-        it('can observe focus when focusing a non field element inside a form', async () => {
-          const focusableElementInsideForm = document.querySelector('#focusable-element-inside-form');
+        it('can not observe focus on non editable focusable elements', async () => {
+          const focusableElementInForm = document.querySelector('#focusable-element-inside-form');
 
-          // Focus the text input first
-          focusableElementInsideForm.focus();
+          focusableElementInForm.focus();
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-          });
+          await window.wait(100);
+
+          assert(window.called.every((call) => call.checkpoint !== 'click'), 'click checkpoint is present');
+        });
+
+
+        it('can observe focus on contenteditable elements inside a form', async () => {
+          const editableElement = document.querySelector('#editable-element-inside-form');
+          editableElement.focus();
+
+          await window.wait(100);
 
           assert(window.called.some((call) => call.checkpoint === 'click'), 'click checkpoint missing');
         });
 
         it('only one click should be sent on click of a field', async () => {
-          const textInput = document.querySelector('input[type="text"]');
+          const textInput = document.querySelector('form input[type="text"]');
           const rect = textInput.getBoundingClientRect();
           await sendMouse({
             type: 'click',
@@ -135,15 +135,14 @@
             ]
           });
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-          });
+          await window.wait(100);
+
           const clicks = window.called.filter((call) => call.checkpoint === 'click');
-          assert(clicks.length === 1, `click is called ${clicks.length} times on a field`);
+          assert(clicks.length === 1, `click is called ${clicks.length} (Expected 1) times on a field`);
         });
 
         it('only one click should be sent on click of a button', async () => {
-          const submitButton = document.querySelector('input[type="submit"]');
+          const submitButton = document.querySelector('button');
           const rect = submitButton.getBoundingClientRect();
           await sendMouse({
             type: 'click',
@@ -153,11 +152,9 @@
             ]
           });
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-          });
+          await window.wait(100);
           const clicks = window.called.filter((call) => call.checkpoint === 'click');
-          assert(clicks.length === 1, `click is called ${clicks.length} times on a button`);
+          assert(clicks.length === 1, `click is called ${clicks.length} (Expected 1) times on a button`);
         });
       });
     });

--- a/test/it/focus.test.html
+++ b/test/it/focus.test.html
@@ -1,0 +1,165 @@
+  <html>
+
+<head>
+  <title>Test Runner</title>
+  <script>
+    // we load from localhost, and have the ability to
+    // change the scripts that are being served. Check the
+    // web-test-runner.config.js file for details
+    window.RUM_BASE = window.origin;
+    window.hlx = {
+      RUM_MASK_URL: 'origin'
+    };
+    // we log what's being sent to the "server"
+    window.called = [];
+    // and navigator.sendBeacon has been replaced with
+    // a call to fakeSendBeacon
+    window.fakeSendBeacon = function (url, payload) {
+      // if payload is a string, we assume it's a JSON string
+      if (typeof payload === 'string') {
+        window.called.push(JSON.parse(payload));
+      } else {
+        // it's a blob
+        payload.text().then((text) => {
+          console.log(JSON.parse(text));
+          window.called.push(JSON.parse(text));
+        });
+      }
+    };
+  </script>
+  <script defer type="text/javascript" src="/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+</head>
+
+<body>
+  <div class="block" data-block-status="loaded">
+    The first block
+    <img src="/test/fixtures/fire.jpg" height="200" width="200">
+  </div>
+  <div id="focusable-element" tabindex="0">
+    Focusable element
+  </div>
+  <form action="javascript:false;" method="POST">
+    <input type="text" name="name" value="John Doe">
+    <input type="email" name="email" value="JohnDoe@example.com">
+    <input type="submit" value="Submit">
+    <div id="focusable-element-inside-form" tabindex="0">
+      Focusable element inside form
+    </div>
+  </form>
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { sendMouse, setViewport } from '@web/test-runner-commands';
+    import { assert } from '@esm-bundle/chai';
+
+    runTests(async () => {
+      describe('Test Focus Tracking', () => {
+        beforeEach(async () => {
+          window.called = [];
+        });
+
+        it('Can observe focus on form fields', async () => {
+          const form = document.querySelector('form');
+
+          form.querySelector('input[type="text"]').focus();
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+          });
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
+          assert(window.called.some((call) => call.checkpoint === 'click'), 'click checkpoint missing');
+        });
+
+        it('Can not observe focus on focusable elements', async () => {
+          const focusableElement = document.querySelector('#focusable-element');
+
+          focusableElement.focus();
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 0);
+          });
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
+          assert(window.called.every((call) => call.checkpoint !== 'click'), 'click checkpoint missing');
+        });
+
+        it('Can observe focus when tabbing between form fields', async () => {
+          const form = document.querySelector('form');
+          const textInput = form.querySelector('input[type="text"]');
+          const emailInput = form.querySelector('input[type="email"]');
+
+          // Focus the text input first
+          textInput.focus();
+
+          // Simulate tab key by focusing the next element
+          const tabEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            code: 'Tab',
+            bubbles: true,
+            cancelable: true
+          });
+          textInput.dispatchEvent(tabEvent);
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
+
+          assert(window.called.some((call) => call.checkpoint === 'click'), 'click checkpoint missing');
+        });
+
+        it('can observe focus when focusing a non field element inside a form', async () => {
+          const focusableElementInsideForm = document.querySelector('#focusable-element-inside-form');
+
+          // Focus the text input first
+          focusableElementInsideForm.focus();
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
+
+          assert(window.called.some((call) => call.checkpoint === 'click'), 'click checkpoint missing');
+        });
+
+        it('only one click should be sent on click of a field', async () => {
+          const textInput = document.querySelector('input[type="text"]');
+          const rect = textInput.getBoundingClientRect();
+          await sendMouse({
+            type: 'click',
+            position: [
+              Math.floor(rect.left + rect.width/2),
+              Math.floor(rect.top + rect.height/2)
+            ]
+          });
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
+          const clicks = window.called.filter((call) => call.checkpoint === 'click');
+          assert(clicks.length === 1, `click is called ${clicks.length} times on a field`);
+        });
+
+        it('only one click should be sent on click of a button', async () => {
+          const submitButton = document.querySelector('input[type="submit"]');
+          const rect = submitButton.getBoundingClientRect();
+          await sendMouse({
+            type: 'click',
+            position: [
+              Math.floor(rect.left + rect.width/2),
+              Math.floor(rect.top + rect.height/2)
+            ]
+          });
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
+          const clicks = window.called.filter((call) => call.checkpoint === 'click');
+          assert(clicks.length === 1, `click is called ${clicks.length} times on a button`);
+        });
+      });
+    });
+  </script>
+</body>


### PR DESCRIPTION
Enhanced click checkpoint for the following elements inside a form

 * input/select/textarea/button : 
 * elements with contenteditable attribute 

Open:
  * elements outside the form element : haven't seen the requirement to track those elements for now. 
  * click triggers two click checkpoints now : one for focus and another for click. One way to differentiate them is add a target property in the click checkpoint when mapping it for focus.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
#332 

Thanks for contributing!
