### PR TITLE
fix: do not track repeating clicks

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -285,8 +285,16 @@ function mediaMCB(mutations) {
 }
 
 function addTrackingFromConfig() {
+  let lastSource;
+  let lastTarget;
   document.addEventListener('click', (event) => {
-    sampleRUM('click', { target: targetSelector(event.target), source: sourceSelector(event.target) });
+    const source = sourceSelector(event.target);
+    const target = targetSelector(event.target);
+    if (source !== lastSource || target !== lastTarget) {
+      sampleRUM('click', { target, source });
+      lastSource = source;
+      lastTarget = target;
+    }
   });
   addCWVTracking();
   addFormTracking(window.document.body);

--- a/test/it/click.test.html
+++ b/test/it/click.test.html
@@ -59,14 +59,16 @@
           });
 
           assert(window.called.length === 1, '1st click checkpoint missing');
+          assert(window.called[0].source === '.block', 'invalid target - click on block');
 
-          await sendMouse({ type: 'click', position: [10, 10] });
+          await sendMouse({ type: 'click', position: [200, 200] });
 
           await new Promise((resolve) => {
             setTimeout(resolve, 100);
           });
 
           assert(window.called.length === 2, '2nd click checkpoint missing');
+          assert(window.called[1].source === 'img', 'invalid target - click on img');
 
           const a = document.getElementById('alink');
           a.click();
@@ -77,6 +79,14 @@
 
           assert(window.called.length === 3 , 'checkpoint for click on link missing');
           assert(window.called[2].source === 'a#alink', 'invalid target for alink checkpoint');
+
+          a.click();
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 100);
+          });
+
+          assert(window.called.length === 3 , '2 consecutive clicks on link should not trigger new checkpoint');
 
           const late = document.createElement('a');
           late.id = 'alatelink';
@@ -91,8 +101,6 @@
 
           assert(window.called.length === 4 , 'checkpoint for click on late added link missing');
           assert(window.called[3].source === 'a#alatelink', 'invalid target for alatelink checkpoint');
-
-          console.log('window.called', window.called);
         });
       });
     });

--- a/test/it/index.test.html
+++ b/test/it/index.test.html
@@ -5,6 +5,7 @@
 </head>
 
 <body>
+  <p>Some content</p>
   <script type="module">
     import { runTests } from '@web/test-runner-mocha';
                       import { sendMouse } from '@web/test-runner-commands';

--- a/test/it/size.test.html
+++ b/test/it/size.test.html
@@ -5,6 +5,7 @@
 </head>
 
 <body>
+  <p>Some content</p>
   <script type="module">
     import { runTests } from '@web/test-runner-mocha';
     import { sendMouse } from '@web/test-runner-commands';


### PR DESCRIPTION
We've identify cases where several thousands of `click` checkpoints are tracked. The `click` handler is pretty straight forward (a simple `document.addEventListener('click'...)`) thus it does not seem to be a code logic issue but rather a browser / project code issue: for some reason, the browser starts firing many repeating `click` events on the same element.

This PR addresses the collection issue: do not track 2 consecutive `click` events on the same element. While this should have low impact on the use cases we want to track, I have identified one: clicks on a toggle button to open and close a menu or an accordion. The element tends to be the same. We'll lost some clicks here. But on the other hand, tracking the 2 identical clicks does not bring much neither, no clue to know how many times open vs close has been trigger anyway.