### PR TITLE
fix: Implement flood control with 1024 max events

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -34,7 +34,10 @@ const blocksMO = window.MutationObserver ? new MutationObserver(blocksMCB)
 // eslint-disable-next-line no-use-before-define, max-len
 const mediaMO = window.MutationObserver ? new MutationObserver(mediaMCB)
   /* c8 ignore next */ : {};
-
+/**
+ * Maximum number of events. The first call will be made by rum-js,
+ * leaving 1023 events for the enhancer to track
+ */
 let maxEvents = 1023;
 
 function trackCheckpoint(checkpoint, data, t) {

--- a/modules/index.js
+++ b/modules/index.js
@@ -39,7 +39,7 @@ let maxEvents = 1023;
 
 function trackCheckpoint(checkpoint, data, t) {
   const { weight, id } = window.hlx.rum;
-  if (isSelected && maxEvents > 0) {
+  if (isSelected && maxEvents) {
     maxEvents -= 1;
     const sendPing = (pdata = data) => {
       // eslint-disable-next-line object-curly-newline, max-len

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@semantic-release/npm": "12.0.1",
         "@web/test-runner": "0.19.0",
         "@web/test-runner-commands": "0.9.0",
-        "@web/test-runner-junit-reporter": "^0.7.2",
+        "@web/test-runner-junit-reporter": "0.7.2",
         "@web/test-runner-mocha": "0.9.0",
         "@web/test-runner-playwright": "0.11.0",
         "c8": "10.1.3",

--- a/test/it/click.test.html
+++ b/test/it/click.test.html
@@ -80,13 +80,15 @@
           assert(window.called.length === 3 , 'checkpoint for click on link missing');
           assert(window.called[2].source === 'a#alink', 'invalid target for alink checkpoint');
 
-          a.click();
+           // Test multiple clicks on link
+          for (let i = 0; i < 11; i++) {
+            a.click();
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
 
-          await new Promise((resolve) => {
-            setTimeout(resolve, 100);
-          });
+          console.log(`window.called: ${window.called.length}`);
 
-          assert(window.called.length === 3 , '2 consecutive clicks on link should not trigger new checkpoint');
+          assert(window.called.length === 12 , '11th consecutive clicks on link should not trigger new checkpoint');
 
           const late = document.createElement('a');
           late.id = 'alatelink';
@@ -99,8 +101,8 @@
             setTimeout(resolve, 100);
           });
 
-          assert(window.called.length === 4 , 'checkpoint for click on late added link missing');
-          assert(window.called[3].source === 'a#alatelink', 'invalid target for alatelink checkpoint');
+          assert(window.called.length === 13 , 'checkpoint for click on late added link missing');
+          assert(window.called[12].source === 'a#alatelink', 'invalid target for alatelink checkpoint');
         });
       });
     });

--- a/test/it/click.test.html
+++ b/test/it/click.test.html
@@ -97,12 +97,12 @@
           assert(window.called.length === 4 , 'checkpoint for click on late added link missing');
           assert(window.called[3].source === 'a#alatelink', 'invalid target for alatelink checkpoint');
           // Test max events
-          const maxEvents = 1025 - window.events.length;
+          const maxEvents = 1026 - window.events.length;
           for (let i = 0; i < maxEvents; i++) {
             a.click();
             await new Promise((resolve) => setTimeout(resolve, 1));
           }
-          assert(window.events.length === 1024 , '1024th event should not trigger new checkpoint');
+          assert(window.events.length === 1024 , '1025th event should not trigger new checkpoint');
         });
       });
     });

--- a/test/it/click.test.html
+++ b/test/it/click.test.html
@@ -12,12 +12,15 @@
     };
     // we log what's being sent to the "server"
     window.called = [];
+    // we need to track the number of events that have been sent
+    window.events = [];
     // and navigator.sendBeacon has been replaced with
     // a call to fakeSendBeacon
     window.fakeSendBeacon = function (url, payload) {
       // if payload is a string, we assume it's a JSON string
       if (typeof payload === 'string') {
         const data = JSON.parse(payload);
+        window.events.push(data);
         if (data.checkpoint === 'click') {
           window.called.push(data);
         }
@@ -25,6 +28,7 @@
         // it's a blob
         payload.text().then((text) => {
           const data = JSON.parse(text);
+          window.events.push(data);
           if (data.checkpoint === 'click') {
             window.called.push(data);
           }
@@ -80,16 +84,6 @@
           assert(window.called.length === 3 , 'checkpoint for click on link missing');
           assert(window.called[2].source === 'a#alink', 'invalid target for alink checkpoint');
 
-           // Test multiple clicks on link
-          for (let i = 0; i < 11; i++) {
-            a.click();
-            await new Promise((resolve) => setTimeout(resolve, 10));
-          }
-
-          console.log(`window.called: ${window.called.length}`);
-
-          assert(window.called.length === 12 , '11th consecutive clicks on link should not trigger new checkpoint');
-
           const late = document.createElement('a');
           late.id = 'alatelink';
           late.onclick = (e) => { e.preventDefault(); };
@@ -100,9 +94,15 @@
           await new Promise((resolve) => {
             setTimeout(resolve, 100);
           });
-
-          assert(window.called.length === 13 , 'checkpoint for click on late added link missing');
-          assert(window.called[12].source === 'a#alatelink', 'invalid target for alatelink checkpoint');
+          assert(window.called.length === 4 , 'checkpoint for click on late added link missing');
+          assert(window.called[3].source === 'a#alatelink', 'invalid target for alatelink checkpoint');
+          // Test max events
+          const maxEvents = 1025 - window.events.length;
+          for (let i = 0; i < maxEvents; i++) {
+            a.click();
+            await new Promise((resolve) => setTimeout(resolve, 1));
+          }
+          assert(window.events.length === 1024 , '1024th event should not trigger new checkpoint');
         });
       });
     });


### PR DESCRIPTION
If the end users are clicking on an element repetitively, it typically indicates a problem like broken experience, confusing UI etc. https://github.com/adobe/helix-rum-enhancer/pull/339 introduced to not to track the repeating clicks, because of which we won't be able to find some of the issues faced by users. 

Currently, PSS considers if the user is clicking 10 times on the same selector with in the same session, we'll record as a rageclick (naming is little different in PSS) and based on such instances, we'll create an opportunity for our customers to fix. For PSS to continue to find these blind clicks and help our customers, we'd like to have the repeating clicks collected as valid RUM checkpoints. 

This PR will introduce the flood control to limit the max events collection to 1024.

Related PRs - https://github.com/adobe/helix-rum-enhancer/pull/339