### PR TITLE
Add source for INP metric

### DIFF
--- a/modules/fflags.js
+++ b/modules/fflags.js
@@ -20,4 +20,5 @@ export const fflags = {
   example: [543, 770, 1136],
   language: [543, 959, 1139, 620],
   allresources: [1139],
+  inpsource: [1139],
 };

--- a/modules/index.js
+++ b/modules/index.js
@@ -86,8 +86,10 @@ function addCWVTracking() {
           if (measurement.name === 'INP' && fflags.has('inpsource')) {
             const sortedEvents = measurement.entries.sort((a, b) => ((a.duration === b.duration)
               ? !!b.target : a.duration < b.duration));
-            const element = sortedEvents.pop()?.target;
-            data.source = sourceSelector(element) || (element && element.outerHTML.slice(0, 30));
+            const event = sortedEvents.pop();
+            const element = event?.target;
+            const eventType = event?.name;
+            data.source = `${eventType}:${sourceSelector(element) || (element && element.outerHTML.slice(0, 30))}`;
           }
           sampleRUM('cwv', data);
         };

--- a/modules/index.js
+++ b/modules/index.js
@@ -83,6 +83,12 @@ function addCWVTracking() {
             data.target = targetSelector(element);
             data.source = sourceSelector(element) || (element && element.outerHTML.slice(0, 30));
           }
+          if (measurement.name === 'INP' && fflags.has('inpsource')) {
+            const sortedEvents = measurement.entries.sort((a, b) => ((a.duration === b.duration)
+              ? !!b.target : a.duration < b.duration));
+            const possibleTarget = sortedEvents.pop()?.target;
+            data.source = sourceSelector(possibleTarget);
+          }
           sampleRUM('cwv', data);
         };
 

--- a/modules/index.js
+++ b/modules/index.js
@@ -86,8 +86,8 @@ function addCWVTracking() {
           if (measurement.name === 'INP' && fflags.has('inpsource')) {
             const sortedEvents = measurement.entries.sort((a, b) => ((a.duration === b.duration)
               ? !!b.target : a.duration < b.duration));
-            const possibleTarget = sortedEvents.pop()?.target;
-            data.source = sourceSelector(possibleTarget);
+            const element = sortedEvents.pop()?.target;
+            data.source = sourceSelector(element) || (element && element.outerHTML.slice(0, 30));
           }
           sampleRUM('cwv', data);
         };


### PR DESCRIPTION
This PR uses the [PerformanceEventTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming) API's to report the event's [target](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming/target) as the `source` for the CWV INP event in RUM.

This will allow better understanding which element the user interacted with on the page when causing the INP value.

The feature is behind a feature flag which is only enabled for https://business.adobe.com/ .

### How it works

The [web vitals](https://github.com/GoogleChrome/web-vitals) `onINP` callback includes a list of `PerformanceEventTiming` entries. The code in this PR sorts these entries first by longest duration, then by events which have a target. This may not be strictly necessary but ensures the most suitable value is reported in all cases. This target, as well as the interaction type, is added as the source of the CVW INP event in RUM.

### Limitations

The `source` will be `null` if the DOM element is removed during the event handler's execution.