### PR TITLE
feat(consent): track consent banner close events

### DIFF
--- a/modules/martech.js
+++ b/modules/martech.js
@@ -16,7 +16,7 @@ export function addCookieConsentTracking(sampleRUM) {
   // eslint-disable-next-line no-param-reassign
   sampleRUM.oneTrustTrackingSet = true;
 
-  function waitForOneTrust(callback) {
+  function onOneTrustLoaded(callback) {
     if (window.OneTrust) {
       callback(window.OneTrust);
       return;
@@ -31,7 +31,7 @@ export function addCookieConsentTracking(sampleRUM) {
     });
   }
 
-  waitForOneTrust((oneTrust) => {
+  onOneTrustLoaded((oneTrust) => {
     if (!oneTrust || typeof oneTrust.IsAlertBoxClosed !== 'function' || typeof oneTrust.OnConsentChanged !== 'function') {
       return;
     }

--- a/modules/martech.js
+++ b/modules/martech.js
@@ -23,6 +23,9 @@ export function addCookieConsentTracking(sampleRUM) {
     }
     Object.defineProperty(window, 'OneTrust', {
       configurable: true,
+      get() {
+        return undefined; // return undefined until it's explicitly set
+      },
       set(value) {
         delete window.OneTrust;
         window.OneTrust = value; // restores normal behavior


### PR DESCRIPTION
## Changes

Instead of reading cookies directly, now we use the [OneTrust Banner SDK](https://developer.onetrust.com/onetrust/docs/javascript-api) to catch the OneTrust events.

## Motivation

We currently don't track the "banner closed" (if) happens after "banner shown". This is especially important to calculate the bounces caused by the cookie consent banner robustly.

this PR introduces a new target `close` to the `consent` checkpoint.

Note: if we decide to go with this impl, I will adjust the tests.

Here's an alternative implementation for the `close` event keeping everything else the same: https://github.com/adobe/helix-rum-enhancer/pull/374


