### PR TITLE
fix(missingresource): exclude specific RUM tracking resources from missing resource reports

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -175,6 +175,7 @@ function addLoadResourceTracking() {
         });
       list.getEntries()
         .filter((e) => e.responseStatus >= 400)
+        .filter((e) => !(new URL(e.name).pathname.match('.*(/\\.rum/1[0-9]{0,3})')))
         .forEach((e) => {
           sampleRUM('missingresource', { source: e.name, target: e.responseStatus });
         });


### PR DESCRIPTION
If the .rum/100 endpoint is blocked by a rate limiter, then each request to it will result in an additional missingresource checkpoint, so this change will exclude all RUM endpoints from missingresource reporting

see https://cq-dev.slack.com/archives/C07198KKQ07/p1740395149011899?thread_ts=1737623480.494499&cid=C07198KKQ07