### PR TITLE
chore: ignore psi check not needed

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -5,10 +5,5 @@
   "baseBranches": [
     "main",
     "1.x"
-  ],
-  "packageRules": [{
-    "matchDepTypes": ["devDependencies"],
-    "labels": ["ignore-psi-check"], 
-    "automerge": true
-  }]
+  ]
 }


### PR DESCRIPTION
helix-rum-enhancer is not an "helix" project anymore, we do not use the delivery mechanism (see https://github.com/adobe/helix-rum-js/pull/215). I disabled the AEM Sync, i.e. the PSI check should not come in anymore. The label on renovate PRs is then not useful anymore...