### PR TITLE
feat: add class in source  selector

### DIFF
--- a/modules/dom.js
+++ b/modules/dom.js
@@ -61,7 +61,10 @@ function getSourceContext(el) {
   const formEl = el.closest('form');
   if (formEl) {
     const id = formEl.getAttribute('id');
-    return `form${id ? `#${id}` : ''}`;
+    if (id) {
+      return `form#${id}`;
+    }
+    return `form${formEl.classList.length > 0 ? `.${formEl.classList[0]}` : ''}`;
   }
   const block = el.closest('.block[data-block-name]');
   return ((block && `.${block.getAttribute('data-block-name')}`)

--- a/test/it/fill.test.html
+++ b/test/it/fill.test.html
@@ -51,7 +51,7 @@
   <div id="focusable-element" tabindex="0">
     Focusable element
   </div>
-  <form action="javascript:false;" method="POST" autocomplete="on">
+  <form class="form-class" action="javascript:false;" method="POST" autocomplete="on">
     <input type="text" name="name" autocomplete="name"/>
     <input type="number" name="number"/>
     <input type="email" name="email" autocomplete="email"/>
@@ -94,8 +94,8 @@
 
           assert(window.called.length === 1, `fill is called ${window.called.length} (Expected 1) times`);
           assert(window.called[0].checkpoint === 'fill', 'checkpoint is not fill');
-          assert(window.called[0].source === `form input[type='number']`,
-            `source ${window.called[0].source} is not form input[type='number']`);
+          assert(window.called[0].source === `form.form-class input[type='number']`,
+            `source ${window.called[0].source} is not form.form-class input[type='number']`);
         });
 
         it('filling form field', async () => {
@@ -112,8 +112,8 @@
 
           assert(window.called.length === 1, `fill is called ${window.called.length} (Expected 1) times`);
           assert(window.called[0].checkpoint === 'fill', 'checkpoint is not fill');
-          assert(window.called[0].source === `form input[type='text']`,
-            `source ${window.called[0].source} is not form input[type='text']`);
+          assert(window.called[0].source === `form.form-class input[type='text']`,
+            `source ${window.called[0].source} is not form.form-class input[type='text']`);
         });
 
         it('filling number field using up and down keys', async () => {
@@ -135,8 +135,8 @@
 
           assert(window.called.length === 1, `fill is called ${window.called.length} (Expected 1) times`);
           assert(window.called[0].checkpoint === 'fill', 'checkpoint is not fill');
-          assert(window.called[0].source === `form input[type='number']`,
-            `source ${window.called[0].source} is not form input[type='number']`);
+          assert(window.called[0].source === `form.form-class input[type='number']`,
+            `source ${window.called[0].source} is not form.form-class input[type='number']`);
         });
 
         it('filling hidden field dispatching change event', async () => {

--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -108,4 +108,19 @@ describe('test dom#sourceSelector', () => {
     // eslint-disable-next-line no-unused-expressions
     expect(sourceSelector()).to.be.undefined;
   });
+
+  it('sourceSelector - select form by class', () => {
+    const form = document.createElement('form');
+    form.classList.add('form-class');
+    form.classList.add('form-class-2');
+    document.body.append(form);
+    expect(sourceSelector(form)).to.be.equal('form.form-class');
+  });
+
+  it('sourceSelector - select form by id', () => {
+    const form = document.createElement('form');
+    form.id = 'form-id';
+    document.body.append(form);
+    expect(sourceSelector(form)).to.be.equal('form#form-id');
+  });
 });


### PR DESCRIPTION
For Click/Fill checkpoints within the form, the form information was getting lost (if it doesn't have a valid class). The information is present with the viewblock and formsubmit checkpoint, so to map the click/fill events with formsubmit and formview had some issues. This PR tries to fix that.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
