### PR TITLE
fix: check for OneTrust PC sdk if banner is not present

### DIFF
--- a/plugins/onetrust.js
+++ b/plugins/onetrust.js
@@ -26,9 +26,16 @@ export default function addCookieConsentTracking({ sampleRUM }) {
     return;
   }
 
-  const otsdk = document.querySelector('#onetrust-banner-sdk');
+  const bannersdk = document.querySelector('#onetrust-banner-sdk');
 
-  if (otsdk && otsdk.checkVisibility && otsdk.checkVisibility()) {
+  if (bannersdk && bannersdk.offsetHeight > 0) {
+    sampleRUMOnce('consent', { source: 'onetrust', target: 'show' });
+    return;
+  }
+
+  const pcsdk = document.querySelector('#onetrust-pc-sdk');
+
+  if (pcsdk && pcsdk.offsetHeight > 0) {
     sampleRUMOnce('consent', { source: 'onetrust', target: 'show' });
     return;
   }

--- a/test/it/onetrust-suppressed.test.html
+++ b/test/it/onetrust-suppressed.test.html
@@ -71,7 +71,7 @@
             && call.source === 'onetrust'), 'suppressed onetrust not detected');
         });
 
-        it('Raises "suppressed" if "#onetrust-consent-sdk" exists but "#onetrust-banner-sdk" does not', async () => {
+        it('Raises "suppressed" if "#onetrust-banner-sdk" does not exist and "#onetrust-pc-sdk" is not displayed', async () => {
 
           await sendMouse({ type: 'click', position: [100, 100] });
 
@@ -84,6 +84,7 @@
           const onetrustWrapper = document.createElement('div');
           onetrustWrapper.innerHTML = fixtureContent;
           document.body.appendChild(onetrustWrapper.firstElementChild);
+          document.body.querySelector('#onetrust-pc-sdk').style.cssText = 'display: none !important';
 
           await new Promise((resolve) => {
             setTimeout(resolve, 3000);

--- a/test/it/onetrust.test.html
+++ b/test/it/onetrust.test.html
@@ -64,6 +64,27 @@
             && call.source === 'onetrust'), 'onetrust not detected');
         });
 
+        it('Raises "show" when "#onetrust-pc-sdk" is visible and "#onetrust-banner-sdk" does not exist', async () => {
+
+          await sendMouse({ type: 'click', position: [100, 100] });
+
+          const fixtureWithoutBanner = await fetch('/test/fixtures/otsdk-without-banner.html');
+          const fixtureContent = await fixtureWithoutBanner.text();
+          const onetrustWrapper = document.createElement('div');
+          onetrustWrapper.innerHTML = fixtureContent;
+          document.body.appendChild(onetrustWrapper.firstElementChild);
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 3000);
+          });
+
+          await sendMouse({ type: 'click', position: [10, 10] });
+
+          assert(window.called.some((call) => call.checkpoint === 'consent'), 'consent checkpoint missing');
+          assert(window.called.some((call) => call.checkpoint === 'consent'
+            && call.target === 'show'
+            && call.source === 'onetrust'), 'onetrust not detected');
+        });
       });
     });
   </script>


### PR DESCRIPTION
Support different DOM structures of domains using OneTrust.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

URL for testing:
- https://harden-onetrust-check--helix-rum-enhancer--adobe.aem.page/

## Related Issues
#415 

Thanks for contributing!
