### PR TITLE
fix(a11y): audience is flagged as using accessibility too often

### DIFF
--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -166,7 +166,7 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
   score += MEDIA_QUERY_PREFERENCES.filter((q) => window.matchMedia(q).matches).length;
 
   const zoom = getZoom();
-  console.error('zoom', zoom);
+  console.error('#3#', zoom);
   if (zoom >= HIGH_ZOOM_LEVEL) {
     score += 3;
   } else if (zoom >= MEDIUM_ZOOM_LEVEL) {

--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -166,7 +166,6 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
   score += MEDIA_QUERY_PREFERENCES.filter((q) => window.matchMedia(q).matches).length;
 
   const zoom = getZoom();
-  console.error('#3#', zoom);
   if (zoom >= HIGH_ZOOM_LEVEL) {
     score += 3;
   } else if (zoom >= MEDIUM_ZOOM_LEVEL) {

--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -15,7 +15,6 @@ const MEDIA_QUERY_PREFERENCES = [
   '(prefers-contrast: high)',
   '(prefers-contrast: more)',
   '(forced-colors: active)',
-  '(prefers-color-scheme: dark)',
   '(prefers-reduced-transparency: reduce)',
 ];
 
@@ -173,7 +172,7 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
     score += 2;
   }
 
-  if (navigator.maxTouchPoints === 0 && !window.matchMedia('(pointer: coarse)').matches) {
+  if (navigator.maxTouchPoints === 0 && window.matchMedia('(pointer: coarse)').matches) {
     score += 2;
   }
 

--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -166,6 +166,7 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
   score += MEDIA_QUERY_PREFERENCES.filter((q) => window.matchMedia(q).matches).length;
 
   const zoom = getZoom();
+  console.error('zoom', zoom);
   if (zoom >= HIGH_ZOOM_LEVEL) {
     score += 3;
   } else if (zoom >= MEDIUM_ZOOM_LEVEL) {

--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -166,6 +166,7 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
   score += MEDIA_QUERY_PREFERENCES.filter((q) => window.matchMedia(q).matches).length;
 
   const zoom = getZoom();
+  console.error('#3#', zoom);
   if (zoom >= HIGH_ZOOM_LEVEL) {
     score += 3;
   } else if (zoom >= MEDIUM_ZOOM_LEVEL) {

--- a/test/it/a11y.audience.medium-zoom.test.html
+++ b/test/it/a11y.audience.medium-zoom.test.html
@@ -18,7 +18,6 @@
       }
     };
   </script>
-  <script defer type="text/javascript" src="/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
 </head>
 <body>
   <p>Some content</p>
@@ -29,6 +28,13 @@
     window.originalVisualViewport = mockVisualViewport(150);
     window.originalMaxTouchPoints = mockMaxTouchPoints(1);
 
+    const loadRumScript = () => new Promise((resolve) => {
+      const script = document.createElement('script');
+      script.src = '/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js';
+      script.onload = () => resolve(script);
+      document.head.appendChild(script);
+    });
+
     runTests(async () => {
       describe('Accessibility Audience Scoring', () => {
         after(() => {
@@ -37,6 +43,8 @@
         });
 
         it('should report `on` for medium zoom', async () => {
+          const rumScript = await loadRumScript();
+
           const audience = await pollForA11y();
           expect(audience).to.exist;
           expect(audience.source).to.equal('on');

--- a/test/it/a11y.audience.zoom.test.html
+++ b/test/it/a11y.audience.zoom.test.html
@@ -5,7 +5,7 @@
     window.RUM_BASE = window.origin;
     window.hlx = {
       RUM_MASK_URL: 'origin',
-      A11Y_REPORT_DELAY: 1000,
+      A11Y_REPORT_DELAY: 3000,
     };
     window.events = [];
     window.fakeSendBeacon = function (url, payload) {

--- a/test/it/a11y.audience.zoom.test.html
+++ b/test/it/a11y.audience.zoom.test.html
@@ -27,16 +27,13 @@
     import { pollForA11y, mockVisualViewport, restoreVisualViewport, mockMaxTouchPoints, restoreMaxTouchPoints } from './a11y.test.utils.js';
     window.originalVisualViewport = mockVisualViewport(200);
     window.originalMaxTouchPoints = mockMaxTouchPoints(1);
-    console.error('#1#', window.innerWidth, window.visualViewport.width);
-    (function loadRumScript() {
+
+    const loadRumScript = () => new Promise((resolve) => {
       const script = document.createElement('script');
       script.src = '/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js';
-      script.onload = () => {
-        console.error('#2#', window.innerWidth, window.visualViewport.width);
-      }
-      script.defer = true;
+      script.onload = () => resolve(script);
       document.head.appendChild(script);
-    })();
+    });
     
     runTests(async () => {
       after(() => {
@@ -46,6 +43,8 @@
 
       describe('Accessibility Audience Scoring', () => {
         it('should report `on` for high zoom', async () => {
+          const rumScript = await loadRumScript();
+
           const audience = await pollForA11y();
           expect(audience).to.exist;
           expect(audience.source).to.equal('on');

--- a/test/it/a11y.audience.zoom.test.html
+++ b/test/it/a11y.audience.zoom.test.html
@@ -33,7 +33,6 @@
       script.src = '/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js';
       script.onload = () => {
         console.error('#2#', window.innerWidth, window.visualViewport.width);
-        resolve(script);
       }
       script.defer = true;
       document.head.appendChild(script);

--- a/test/it/a11y.audience.zoom.test.html
+++ b/test/it/a11y.audience.zoom.test.html
@@ -18,7 +18,6 @@
       }
     };
   </script>
-  <script defer type="text/javascript" src="/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
 </head>
 <body>
   <p>Some content</p>
@@ -28,6 +27,17 @@
     import { pollForA11y, mockVisualViewport, restoreVisualViewport, mockMaxTouchPoints, restoreMaxTouchPoints } from './a11y.test.utils.js';
     window.originalVisualViewport = mockVisualViewport(200);
     window.originalMaxTouchPoints = mockMaxTouchPoints(1);
+    console.error('#1#', window.innerWidth, window.visualViewport.width);
+    (function loadRumScript() {
+      const script = document.createElement('script');
+      script.src = '/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js';
+      script.onload = () => {
+        console.error('#2#', window.innerWidth, window.visualViewport.width);
+        resolve(script);
+      }
+      script.defer = true;
+      document.head.appendChild(script);
+    })();
     
     runTests(async () => {
       after(() => {

--- a/test/it/a11y.audience.zoom.test.html
+++ b/test/it/a11y.audience.zoom.test.html
@@ -27,13 +27,10 @@
     import { pollForA11y, mockVisualViewport, restoreVisualViewport, mockMaxTouchPoints, restoreMaxTouchPoints } from './a11y.test.utils.js';
     window.originalVisualViewport = mockVisualViewport(200);
     window.originalMaxTouchPoints = mockMaxTouchPoints(1);
-    console.error('#1#', window.innerWidth, window.visualViewport.width);
+    // Making sure to load RUM after the viewport is properly mocked
     (function loadRumScript() {
       const script = document.createElement('script');
       script.src = '/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js';
-      script.onload = () => {
-        console.error('#2#', window.innerWidth, window.visualViewport.width);
-      }
       script.defer = true;
       document.head.appendChild(script);
     })();

--- a/test/it/a11y.audience.zoom.test.html
+++ b/test/it/a11y.audience.zoom.test.html
@@ -27,10 +27,13 @@
     import { pollForA11y, mockVisualViewport, restoreVisualViewport, mockMaxTouchPoints, restoreMaxTouchPoints } from './a11y.test.utils.js';
     window.originalVisualViewport = mockVisualViewport(200);
     window.originalMaxTouchPoints = mockMaxTouchPoints(1);
-    // Making sure to load RUM after the viewport is properly mocked
+    console.error('#1#', window.innerWidth, window.visualViewport.width);
     (function loadRumScript() {
       const script = document.createElement('script');
       script.src = '/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js';
+      script.onload = () => {
+        console.error('#2#', window.innerWidth, window.visualViewport.width);
+      }
       script.defer = true;
       document.head.appendChild(script);
     })();

--- a/test/it/broken-plugin.test.html
+++ b/test/it/broken-plugin.test.html
@@ -49,13 +49,13 @@
           // sort called by the first argument
           called.sort((a, b) => a[0].localeCompare(b[0]));
 
-          expect(called).to.have.lengthOf(4);
-          expect(called[1][0]).to.equal('click');
+          expect(called).to.have.lengthOf(3);
+          expect(called[0][0]).to.equal('click');
 
-          expect(called[2][0]).to.equal('enter');
+          expect(called[1][0]).to.equal('enter');
 
-          expect(called[3][0]).to.equal('language');
-          expect(called[3][1].source).to.equal('en-NZ');
+          expect(called[2][0]).to.equal('language');
+          expect(called[2][1].source).to.equal('en-NZ');
         });
 
       });

--- a/test/it/index.test.html
+++ b/test/it/index.test.html
@@ -49,15 +49,13 @@
           // sort called by the first argument
           called.sort((a, b) => a[0].localeCompare(b[0]));
 
-          expect(called[0][0]).to.equal('a11y');
+          expect(called).to.have.lengthOf(3);
+          expect(called[0][0]).to.equal('click');
 
-          expect(called).to.have.lengthOf(4);
-          expect(called[1][0]).to.equal('click');
+          expect(called[1][0]).to.equal('enter');
 
-          expect(called[2][0]).to.equal('enter');
-
-          expect(called[3][0]).to.equal('language');
-          expect(called[3][1].source).to.equal('en-NZ');
+          expect(called[2][0]).to.equal('language');
+          expect(called[2][1].source).to.equal('en-NZ');
         });
 
       });

--- a/test/it/navigation.test.html
+++ b/test/it/navigation.test.html
@@ -69,7 +69,7 @@
             setTimeout(resolve, 1000);
           });
 
-          expect(called).to.have.lengthOf(7, 'we expect six calls, got ' + called.map((c) => c[0]).join(', '));
+          expect(called).to.have.lengthOf(6, 'we expect six calls, got ' + called.map((c) => c[0]).join(', '));
           expect(called[0][0]).to.equal('navigate');
           expect(called[1][0]).to.equal('redirect');
           expect(called[1][1].target).to.equal(1);
@@ -77,7 +77,6 @@
           expect(called[3][0]).to.equal('back_forward');
           expect(called[4][0]).to.equal('prerender');
           expect(called[5][0]).to.equal('language');
-          expect(called[6][0]).to.equal('a11y');
         });
 
       });

--- a/test/it/size.test.html
+++ b/test/it/size.test.html
@@ -45,8 +45,8 @@
           // click anywhere, just to make sure the script is running
           await sendMouse({ type: 'click', position: [10, 10] });
 
-          expect(called).to.have.lengthOf(4, 'three calls should have been made, got: ' + called.map((c) => c[0]).join(', '));
-          expect(called[3][0]).to.equal('click');
+          expect(called).to.have.lengthOf(3, 'three calls should have been made, got: ' + called.map((c) => c[0]).join(', '));
+          expect(called[2][0]).to.equal('click');
 
           let transferSize = 0;
           // check the size of loaded JS files


### PR DESCRIPTION
Turns out the initial PR have a few flaws:

1. Tracking dark theme as an accessibility feature is a bad idea… our data shows that a lot of users have it enabled on some sites
2. The coarse pointer logic was reversed