### PR TITLE
feat(a11y): introduce granular a11y level detection

### DIFF
--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -239,7 +239,7 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
   focusLossObserver.observe(document, { childList: true, subtree: true });
 
   // --- Final Reporting ---
-  if (score >= 1) {
+  if (score >= 7) {
     reportAudience();
   } else {
     setTimeout(

--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -139,6 +139,7 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
     if (focusHistory.length >= minSeqLength) {
       for (let seqLength = 2; seqLength <= 4; seqLength += 1) {
         if (detectRepeatingSequence(elements, seqLength)) {
+          /* c8 ignore next 4 */
           return;
         }
       }

--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -169,7 +169,6 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
     if (totalCount >= BEHAVIORAL_MIN_EVENTS && !reported) {
       if (keyboardCount / totalCount > 0.7) {
         score += AAA_WEIGHT;
-        console.log('keyboard', score);
       }
       reportAudience();
     }
@@ -179,27 +178,22 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
   Object.entries(PREFERENCE_WEIGHTS).forEach(([query, queryWeight]) => {
     if (window.matchMedia(query).matches) {
       score += queryWeight;
-      console.log('preference', query, score);
     }
   });
 
   const zoom = getZoom();
   if (zoom >= HIGH_ZOOM_LEVEL) {
     score += AA_WEIGHT;
-    console.log('high zoom', score);
   } else if (zoom >= MEDIUM_ZOOM_LEVEL) {
     score += A_WEIGHT;
-    console.log('medium zoom', score);
   }
 
   if (navigator.maxTouchPoints === 0 && window.matchMedia('(pointer: coarse)').matches) {
     score += AA_WEIGHT;
-    console.log('pointer', score);
   }
 
   if (window.matchMedia('(hover: none)').matches) {
     score += AA_WEIGHT;
-    console.log('hover', score);
   }
 
   // --- Event Listeners & Observers ---

--- a/plugins/a11y.js
+++ b/plugins/a11y.js
@@ -169,6 +169,7 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
     if (totalCount >= BEHAVIORAL_MIN_EVENTS && !reported) {
       if (keyboardCount / totalCount > 0.7) {
         score += AAA_WEIGHT;
+        console.log('keyboard', score);
       }
       reportAudience();
     }
@@ -178,22 +179,27 @@ export default function addAccessibilityAudienceTracking({ sampleRUM, sourceSele
   Object.entries(PREFERENCE_WEIGHTS).forEach(([query, queryWeight]) => {
     if (window.matchMedia(query).matches) {
       score += queryWeight;
+      console.log('preference', query, score);
     }
   });
 
   const zoom = getZoom();
   if (zoom >= HIGH_ZOOM_LEVEL) {
     score += AA_WEIGHT;
+    console.log('high zoom', score);
   } else if (zoom >= MEDIUM_ZOOM_LEVEL) {
     score += A_WEIGHT;
+    console.log('medium zoom', score);
   }
 
   if (navigator.maxTouchPoints === 0 && window.matchMedia('(pointer: coarse)').matches) {
     score += AA_WEIGHT;
+    console.log('pointer', score);
   }
 
   if (window.matchMedia('(hover: none)').matches) {
     score += AA_WEIGHT;
+    console.log('hover', score);
   }
 
   // --- Event Listeners & Observers ---

--- a/test/it/a11y.audience.high.test.html
+++ b/test/it/a11y.audience.high.test.html
@@ -1,0 +1,68 @@
+<html>
+<head>
+  <title>A11y Audience - High Score Test</title>
+  <script>
+    window.RUM_BASE = window.origin;
+    window.hlx = {
+      RUM_MASK_URL: 'origin',
+      A11Y_REPORT_DELAY: 1000,
+    };
+    window.events = [];
+    window.fakeSendBeacon = function (url, payload) {
+      if (typeof payload === 'string') {
+        window.events.push(JSON.parse(payload));
+      } else {
+        payload.text().then((text) => {
+          window.events.push(JSON.parse(text));
+        });
+      }
+    };
+    window.originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query) => ({
+      matches: query === '(forced-colors: active)' || 
+               query === '(pointer: coarse)' ||
+               query === '(prefers-contrast: more)' ||
+               query === '(hover: none)'
+    });
+  </script>
+  <script defer type="text/javascript" src="/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+</head>
+<body>
+  <p>Some content for high accessibility score test</p>
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { expect } from '@esm-bundle/chai';
+    import { pollForA11y, mockVisualViewport, restoreVisualViewport, mockMaxTouchPoints, restoreMaxTouchPoints } from './a11y.test.utils.js';
+    
+    // Mock high zoom level (≥200%) for 2 points
+    window.originalVisualViewport = mockVisualViewport(200);
+    // Mock maxTouchPoints = 0 to trigger the specific condition
+    window.originalMaxTouchPoints = mockMaxTouchPoints(0);
+
+    runTests(async () => {
+      describe('Accessibility Audience Scoring', () => {
+        after(() => {
+          window.matchMedia = window.originalMatchMedia;
+          restoreVisualViewport(window.originalVisualViewport);
+          restoreMaxTouchPoints(window.originalMaxTouchPoints);
+        });
+
+        it('should report `high` for a device with high accessibility needs', async () => {
+          // This test should trigger multiple conditions to ensure >7 points:
+          // - (forced-colors: active) = 4 points (AAA_WEIGHT)
+          // - (prefers-contrast: more) = 2 points (AA_WEIGHT)
+          // - (hover: none) = 2 points (AA_WEIGHT)
+          // - High zoom (≥200%) = 2 points (AA_WEIGHT) 
+          // - navigator.maxTouchPoints === 0 && (pointer: coarse) = 2 points (AA_WEIGHT)
+          // Total: 4 + 2 + 2 + 2 + 2 = 12 points > 7, should be "high"
+          
+          const audience = await pollForA11y();
+          expect(audience).to.exist;
+          expect(audience.source).to.equal('high');
+          expect(audience.target).to.equal('off:low:medium:high');
+        });
+      });
+    });
+  </script>
+</body>
+</html> 

--- a/test/it/a11y.audience.hover.test.html
+++ b/test/it/a11y.audience.hover.test.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>A11y Audience - Keyboard Usage Test</title>
+  <title>A11y Audience - Hover None Test</title>
   <script>
     window.RUM_BASE = window.origin;
     window.hlx = {
@@ -17,6 +17,8 @@
         });
       }
     };
+    window.originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query) => ({ matches: query === '(hover: none)' });
   </script>
   <script defer type="text/javascript" src="/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
 </head>
@@ -24,27 +26,23 @@
   <p>Some content</p>
   <script type="module">
     import { runTests } from '@web/test-runner-mocha';
-    import { sendKeys } from '@web/test-runner-commands';
     import { expect } from '@esm-bundle/chai';
     import { pollForA11y, mockVisualViewport, restoreVisualViewport, mockMaxTouchPoints, restoreMaxTouchPoints } from './a11y.test.utils.js';
     window.originalVisualViewport = mockVisualViewport(100);
-    window.originalMaxTouchPoints = mockMaxTouchPoints(1);
+    window.originalMaxTouchPoints = mockMaxTouchPoints(0);
 
     runTests(async () => {
       describe('Accessibility Audience Scoring', () => {
         after(() => {
+          window.matchMedia = window.originalMatchMedia;
           restoreVisualViewport(window.originalVisualViewport);
           restoreMaxTouchPoints(window.originalMaxTouchPoints);
         });
 
-        it('should report `medium` for heavy keyboard usage', async () => {
-          for (let i = 0; i < 12; i += 1) {
-            await sendKeys({ press: 'ArrowDown' });
-          }
-
+        it('should report `low` for a device with no hover capability', async () => {
           const audience = await pollForA11y();
           expect(audience).to.exist;
-          expect(audience.source).to.equal('medium');
+          expect(audience.source).to.equal('low');
         });
       });
     });

--- a/test/it/a11y.audience.medium-zoom.test.html
+++ b/test/it/a11y.audience.medium-zoom.test.html
@@ -42,12 +42,12 @@
           restoreMaxTouchPoints(window.originalMaxTouchPoints);
         });
 
-        it('should report `on` for medium zoom', async () => {
+        it('should report `low` for medium zoom', async () => {
           const rumScript = await loadRumScript();
 
           const audience = await pollForA11y();
           expect(audience).to.exist;
-          expect(audience.source).to.equal('on');
+          expect(audience.source).to.equal('low');
         });
       });
     });

--- a/test/it/a11y.audience.medium-zoom.test.html
+++ b/test/it/a11y.audience.medium-zoom.test.html
@@ -17,6 +17,8 @@
         });
       }
     };
+    window.originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query) => ({ matches: false });
   </script>
 </head>
 <body>
@@ -37,7 +39,8 @@
 
     runTests(async () => {
       describe('Accessibility Audience Scoring', () => {
-        after(() => {
+        after(() => { 
+          window.matchMedia = window.originalMatchMedia;
           restoreVisualViewport(window.originalVisualViewport);
           restoreMaxTouchPoints(window.originalMaxTouchPoints);
         });

--- a/test/it/a11y.audience.preference.test.html
+++ b/test/it/a11y.audience.preference.test.html
@@ -39,10 +39,10 @@
           restoreMaxTouchPoints(window.originalMaxTouchPoints);
         });
 
-        it('should report `on` for a single preference', async () => {
+        it('should report `low` for a single preference', async () => {
           const audience = await pollForA11y();
           expect(audience).to.exist;
-          expect(audience.source).to.equal('on');
+          expect(audience.source).to.equal('low');
         });
       });
     });

--- a/test/it/a11y.audience.zoom.test.html
+++ b/test/it/a11y.audience.zoom.test.html
@@ -17,6 +17,8 @@
         });
       }
     };
+    window.originalMatchMedia = window.matchMedia;
+    window.matchMedia = (query) => ({ matches: false });
   </script>
 </head>
 <body>
@@ -37,6 +39,7 @@
     
     runTests(async () => {
       after(() => {
+        window.matchMedia = window.originalMatchMedia;
         restoreVisualViewport(window.originalVisualViewport);
         restoreMaxTouchPoints(window.originalMaxTouchPoints);
       });

--- a/test/it/a11y.audience.zoom.test.html
+++ b/test/it/a11y.audience.zoom.test.html
@@ -42,12 +42,12 @@
       });
 
       describe('Accessibility Audience Scoring', () => {
-        it('should report `on` for high zoom', async () => {
+        it('should report `low` for high zoom', async () => {
           const rumScript = await loadRumScript();
 
           const audience = await pollForA11y();
           expect(audience).to.exist;
-          expect(audience.source).to.equal('on');
+          expect(audience.source).to.equal('low');
         });
       });
     });


### PR DESCRIPTION
This pull request overhauls the accessibility audience detection plugin to provide more granular and actionable insights into user needs. The previous binary (`on`/`off`) reporting has been replaced with a weighted scoring system that categorizes users into one of four audience segments: `off`, `low`, `medium`, or `high`. It loosely follows the A/AA/AAA levels.

## Key Changes

- *Weighted Scoring System*: Introduced a scoring model inspired by WCAG conformance levels (`A_WEIGHT`, `AA_WEIGHT`, `AAA_WEIGHT`) to give more significance to stronger accessibility signals.
- **Granular Audience Reporting**: The sampleRUM event for the a11y checkpoint now reports a `source` of `off`, `low`, `medium`, or `high`, providing a clearer picture of the user's potential needs.
- **Expanded Signal Detection**: The scoring now incorporates a wider range of configuration-based signals, including:
  - User Preferences: the legacy `-ms-high-contrast`.
  - Input Method: Detects heavy keyboard usage and lack of hover capability (`(hover: none)`).

This change allows us to move beyond simple detection and begin to understand the degree to which users are relying on accessibility features, enabling more targeted improvements to the user experience.