### PR TITLE
fix: initialization logic

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -361,7 +361,7 @@ function addTrackingFromConfig() {
   });
 }
 
-function init() {
+function initEnhancer() {
   try {
     if (sampleRUM) {
       addTrackingFromConfig();
@@ -374,4 +374,4 @@ function init() {
   }
 }
 
-init();
+initEnhancer();


### PR DESCRIPTION
Tests in other repos are actually explicitly checking for `initEnhancer` and we inadvertently lost this recently.
See: https://github.com/adobe/helix-rum-collector/actions/runs/16274260050