### PR TITLE
feat: disable tracking for a specific domain

### DIFF
--- a/modules/fflags.js
+++ b/modules/fflags.js
@@ -19,5 +19,5 @@ export const fflags = {
   example: [543, 770, 1136],
   allresources: [543, 1139],
   a11y: [557, 781, 897, 955, 959],
-  noresources: [397], // applyonline.hdfcbank.com - disable resource tracking
+  notracking: [397], // applyonline.hdfcbank.com - disable all RUM tracking
 };

--- a/modules/index.js
+++ b/modules/index.js
@@ -172,6 +172,11 @@ function createPluginMO(key, params, usp) {
 let maxEvents = 1023;
 
 function trackCheckpoint(checkpoint, data, t) {
+  // Skip all tracking if notracking flag is enabled
+  if (fflags.has('notracking')) {
+    return;
+  }
+
   const { weight, id } = window.hlx.rum;
   if (isSelected && maxEvents) {
     maxEvents -= 1;
@@ -244,11 +249,6 @@ function addNavigationTracking() {
 }
 
 function addLoadResourceTracking() {
-  // Skip resource tracking if noresources flag is enabled
-  if (fflags.has('noresources')) {
-    return;
-  }
-
   const observer = new PerformanceObserver((list) => {
     try {
       const entries = list.getEntries();


### PR DESCRIPTION
- Add noresources feature flag in fflags.js
- Modify addLoadResourceTracking to check noresources flag
- Enable flag for applyonline.hdfcbank.com (hash: 397)
- When enabled, disables both loadresource and missingresource checkpoints

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!


## Test URL
https://feat/noresources-flag--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html

URL for testing:

- https://feat-noresources-flag--helix-rum-enhancer--adobe.aem.page/
