### PR TITLE
Remove blackbar-only TrustArc detection

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -39,7 +39,7 @@ const CONSENT_PROVIDERS = [
   },
   {
     name: 'trustarc',
-    detect: () => ['notice_gdpr_prefs', 'notice_preferences'].some(hasCookieKey) || document.querySelector('#truste-consent-track, #consent_blackbar'),
+    detect: () => ['notice_gdpr_prefs', 'notice_preferences'].some(hasCookieKey) || document.querySelector('#truste-consent-track'),
   },
   {
     name: 'usercentrics',

--- a/test/it/trustarc-suppressed.test.html
+++ b/test/it/trustarc-suppressed.test.html
@@ -42,11 +42,10 @@
       });
 
       describe('TrustArc Integration Tests', () => {
-        it('Sends consent event with target "suppressed" when only #consent-blackbar is present', async () => {
-          await loadFixture('/test/fixtures/trustarc-suppressed.html')
+        it('Does not detect TrustArc when only #consent_blackbar is present', async () => {
+          await loadFixture('/test/fixtures/trustarc-suppressed.html');
           await new Promise((resolve) => setTimeout(resolve, 3000));
-          assert(window.called.some((call) => call.checkpoint === 'consent'), 'consent checkpoint missing');
-          assert(window.called.some((call) => call.checkpoint === 'consent' && call.target === 'suppressed' && call.source === 'trustarc'), 'trustarc did not report suppressed when elements hidden');
+          assert(!window.called.some((call) => call.checkpoint === 'consent' && call.source === 'trustarc'), 'trustarc should not be detected from blackbar-only markup');
         });
 
         it('Sends consent event with target "suppressed" when only #truste-consent-content is present and hidden', async () => {


### PR DESCRIPTION
## Summary
- remove `#consent_blackbar` from TrustArc provider detection to prevent false positives
- keep TrustArc detection based on TrustArc cookies or `#truste-consent-track`
- update TrustArc suppressed integration test to assert blackbar-only markup does not trigger TrustArc

## Test URL
https://remove-trustarc-false-positive--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
