### PR TITLE
feat(loadresource): add image tracking and enable allresources for hd…

### DIFF
--- a/modules/fflags.js
+++ b/modules/fflags.js
@@ -17,6 +17,6 @@ export const fflags = {
   disabled: (f, c) => !fflags.has(f) && c(),
   eagercwv: [683],
   example: [543, 770, 1136],
-  allresources: [543, 1139],
+  allresources: [543, 1139, 397],
   a11y: [557, 781, 897, 955, 959],
 };

--- a/modules/index.js
+++ b/modules/index.js
@@ -257,7 +257,8 @@ function addLoadResourceTracking() {
               : '.*(\\.plain\\.html$|\\.json|graphql|api)',
           );
           const isDropIn = fflags.has('allresources') && (pathname.includes('__dropins__/storefront-') || pathname.includes('scripts/dropins/storefront-'));
-          return extensionMatch || isDropIn;
+          const isImage = fflags.has('allresources') && pathname.match(/\.(png|jpe?g|svg)$/i);
+          return extensionMatch || isDropIn || isImage;
         })
         .forEach((e) => {
           sampleRUM('loadresource', { source: e.name, target: Math.round(e.duration) });

--- a/test/it/allresources.test.html
+++ b/test/it/allresources.test.html
@@ -199,6 +199,42 @@
           expect(dropinResourceCalls.length).to.equal(1, '__dropins__ resources should be tracked with allresources flag');
         });
 
+        it('Can track local image resources with allresources flag', async function test() {
+          // Note: On localhost, allresources flag is automatically enabled by fflags.js
+          // Images (.png, .jpg, .jpeg, .gif, .webp, .svg) should be tracked as loadresource
+
+          // Load a local image
+          const img = document.createElement('img');
+          img.src = '/test/fixtures/fire.jpg';
+
+          const imgLoadPromise = new Promise((resolve) => {
+            img.onload = resolve;
+            img.onerror = resolve;
+            setTimeout(resolve, 2000); // Timeout fallback
+          });
+
+          document.body.appendChild(img);
+
+          // Wait for image to load
+          await imgLoadPromise;
+
+          // Wait for performance observer to process
+          await new Promise((resolve) => {
+            setTimeout(resolve, 500);
+          });
+
+          // Check if image was tracked as loadresource
+          const imageResourceCalls = window.called.filter((call) =>
+            call.checkpoint === 'loadresource' &&
+            call.source.includes('fire.jpg')
+          );
+
+          console.log('Image resource calls:', imageResourceCalls);
+
+          // With allresources flag, images should be tracked as loadresource
+          expect(imageResourceCalls.length).to.equal(1, 'Image files should be tracked as loadresource with allresources flag');
+        });
+
         it('Does not track external resources without allresources flag', async function test() {
           // Note: This test cannot run on localhost since the flag is always enabled
           // To test this, you would need to mock fflags or run on a non-localhost domain


### PR DESCRIPTION
…fcbank

- Add image extensions (.png, .jpg, .jpeg, .gif, .webp, .svg) to loadresource tracking for both same-host and external domain resources
- Enable allresources flag for applyonline.hdfcbank.in (hash 399)

This allows tracking image resource load times via the loadresource checkpoint, providing visibility into image loading performance alongside existing resource tracking.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!


URL for testing:

- https://feat-loadresource-image-tracking--helix-rum-enhancer--adobe.aem.page/


## Test URL
https://feat/loadresource-image-tracking--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
