### PR TITLE
fix: track submit button click as formsubmit if submit event blocked

### DIFF
--- a/test/it/formbuttonclick.test.html
+++ b/test/it/formbuttonclick.test.html
@@ -1,0 +1,73 @@
+<html>
+
+<head>
+  <title>Test Runner</title>
+  <script>
+    // we load from localhost, and have the ability to
+    // change the scripts that are being served. Check the
+    // web-test-runner.config.js file for details
+    window.RUM_BASE = window.origin;
+    // we log what's being sent to the "server"
+    window.called = [];
+    // and navigator.sendBeacon has been replaced with
+    // a call to fakeSendBeacon
+    window.fakeSendBeacon = function (url, payload) {
+      // if payload is a string, we assume it's a JSON string
+      if (typeof payload === 'string') {
+        window.called.push(JSON.parse(payload));
+      } else {
+        // it's a blob
+        payload.text().then((text) => {
+          window.called.push(JSON.parse(text));
+        });
+      }
+    };
+  </script>
+  <script defer type="text/javascript" src="/.rum/@adobe/helix-rum-js@^2/dist/rum-standalone.js"></script>
+</head>
+
+<body>
+  <div class="block" data-block-status="loaded">
+    The first block
+    <img src="/test/fixtures/fire.jpg" height="200" width="200">
+  </div>
+  <div class="block" data-block-status="loaded">
+    <form action="javascript:false;" method="POST">
+      <input type="text" name="name" value="John Doe">
+      <button type="submit">Submit</button>
+    </form>
+    <script>
+      // Block the form submit entirely so it never fires
+      document.querySelector('form').addEventListener('submit', (e) => {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      });
+    </script>
+  </div>
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { sendMouse, setViewport } from '@web/test-runner-commands';
+    import { assert } from '@esm-bundle/chai';
+
+    runTests(async () => {
+      describe('Test Form Button Click Fallback', () => {
+        it('Can track formsubmit via submit button click when form submit is blocked', async function test() {
+          const form = document.querySelector('form');
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 2000);
+          });
+
+          // click the submit button – the form submit event is blocked by
+          // stopImmediatePropagation, so only the click fallback path fires
+          form.querySelector('button[type="submit"]').click();
+
+          await new Promise((resolve) => {
+            setTimeout(resolve, 2000);
+          });
+          assert(window.called.some((call) => call.checkpoint === 'formsubmit'), 'formsubmit checkpoint missing');
+        });
+      });
+    });
+  </script>
+</body></html>

--- a/test/unit/form-submit-fallback.test.html
+++ b/test/unit/form-submit-fallback.test.html
@@ -1,0 +1,155 @@
+<html>
+
+<head>
+  <title>Form Submit Click-Fallback Test Runner</title>
+  <style>
+    .test-form {
+      margin: 20px 0;
+      padding: 10px;
+      border: 1px solid #ccc;
+    }
+  </style>
+</head>
+
+<body>
+  <!-- Test 1: Form submit fires normally – click fallback should be cancelled -->
+  <div id="submit-fires-container">
+    <form id="submit-fires-form" class="test-form" action="javascript:false;" method="POST">
+      <input type="text" name="name" value="John Doe">
+      <input type="submit" value="Submit">
+    </form>
+  </div>
+  <script>
+    // Allow submit to fire, but prevent navigation
+    document.querySelector('#submit-fires-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+    });
+  </script>
+
+  <!-- Test 2: Form submit is blocked – click fallback should fire -->
+  <div id="submit-blocked-container">
+    <form id="submit-blocked-form" class="test-form" action="javascript:false;" method="POST">
+      <input type="text" name="name" value="Jane Doe">
+      <button type="submit">Submit</button>
+    </form>
+  </div>
+  <script>
+    // Block submit entirely so the plugin's submit handler never runs
+    document.querySelector('#submit-blocked-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    });
+  </script>
+
+  <!-- Test 3: Multiple rapid clicks – only one formsubmit should be sent -->
+  <div id="multi-click-container">
+    <form id="multi-click-form" class="test-form" action="javascript:false;" method="POST">
+      <input type="text" name="name" value="Multi Click">
+      <input type="submit" value="Submit">
+    </form>
+  </div>
+  <script>
+    // Block submit entirely
+    document.querySelector('#multi-click-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    });
+  </script>
+
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { expect } from '@esm-bundle/chai';
+    import addFormTracking from '../../plugins/form.js';
+
+    // Mock helpers
+    const mockSourceSelector = (element) => {
+      return element.tagName.toLowerCase() + (element.name ? `[name="${element.name}"]` : '');
+    };
+
+    const mockTargetSelector = (element) => {
+      return element.tagName.toLowerCase();
+    };
+
+    const mockCreateMO = (cb) => ({
+      observe: () => { cb([]); },
+    });
+
+    const mockGetIntersectionObserver = () => ({
+      observe: () => {},
+    });
+
+    function initTracking(sampleRUM, context) {
+      addFormTracking({
+        sampleRUM,
+        sourceSelector: mockSourceSelector,
+        targetSelector: mockTargetSelector,
+        context,
+        createMO: mockCreateMO,
+        getIntersectionObserver: mockGetIntersectionObserver,
+      });
+    }
+
+    runTests(async () => {
+      describe('Form Submit Click-Fallback', () => {
+        let calls;
+
+        beforeEach(() => {
+          calls = [];
+        });
+
+        it('should cancel click fallback when form submit fires', async function test() {
+          const form = document.querySelector('#submit-fires-form');
+          const recorder = (checkpoint, data) => { calls.push({ checkpoint, ...data }); };
+          initTracking(recorder, document.querySelector('#submit-fires-container'));
+
+          // Click the submit button – submit event will fire (only prevented, not stopped)
+          form.querySelector('input[type="submit"]').click();
+
+          // Wait for the setTimeout(0) fallback window to pass
+          await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+          // The submit handler fires and cancels the fallback, so we should get
+          // exactly one formsubmit – from the submit handler, not the click fallback.
+          const submits = calls.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submits.length).to.equal(1, 'Should have exactly 1 formsubmit from the submit handler');
+        });
+
+        it('should fire click fallback when form submit is blocked', async function test() {
+          const form = document.querySelector('#submit-blocked-form');
+          const recorder = (checkpoint, data) => { calls.push({ checkpoint, ...data }); };
+          initTracking(recorder, document.querySelector('#submit-blocked-container'));
+
+          // Click the submit button – submit event is blocked by stopImmediatePropagation
+          form.querySelector('button[type="submit"]').click();
+
+          // Wait for the setTimeout(0) fallback to execute
+          await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+          const submits = calls.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submits.length).to.equal(1, 'Should have exactly 1 formsubmit from the click fallback');
+        });
+
+        it('should send only one formsubmit on multiple rapid clicks', async function test() {
+          const form = document.querySelector('#multi-click-form');
+          const recorder = (checkpoint, data) => { calls.push({ checkpoint, ...data }); };
+          initTracking(recorder, document.querySelector('#multi-click-container'));
+
+          const btn = form.querySelector('input[type="submit"]');
+
+          // Rapid-fire three clicks
+          btn.click();
+          btn.click();
+          btn.click();
+
+          // Wait for the fallback timeout to settle
+          await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+          const submits = calls.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submits.length).to.equal(1, 'Should have exactly 1 formsubmit despite multiple clicks');
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
### Description

Tracks submit event from submit button clicks if form submit action is blocked by JS

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

## Test URL
http://forms-send-submit-event-for-button-clicks--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.

Thanks for contributing!
