### PR TITLE
fix: use npm OIDC trusted publishers and update Node.js version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,11 +9,14 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Use Node.js 20.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v6
         with:
           node-version: '24.x'
@@ -42,7 +45,6 @@ jobs:
         run: npm run semantic-release-dry
         env:
           GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
@@ -69,6 +71,5 @@ jobs:
       - run: npm run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary
- Remove `NPM_TOKEN` from both test and release jobs, switching to GitHub Actions OIDC for npm authentication
- Add `id-token: write` permission to the test job so the semantic-release dry run can verify OIDC
- Fix misleading "Use Node.js 20.x" step label (was already using 24.x)

This completes the work started in #498, which added OIDC permissions to the release job but left `NPM_TOKEN` in place. Since `@semantic-release/npm` tries token auth first when `NPM_TOKEN` is set, the expired token causes a 401 before OIDC gets a chance.

## Prerequisites
npm trusted publishers must be configured for `@adobe/helix-rum-enhancer` on [npmjs.com](https://www.npmjs.com/package/@adobe/helix-rum-enhancer/access) for the `adobe/helix-rum-enhancer` GitHub repository.

## Test plan
- [ ] Verify npm trusted publishers are configured on npmjs.com
- [ ] CI dry-run passes with OIDC (no NPM_TOKEN)
- [ ] Merge and verify release job publishes successfully via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test URL
https://fix/oidc-npm-publish--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
