### PR TITLE
fix: add checks:write permission for test-summary action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
       id-token: write
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Add `checks: write` to the test job's permissions block so `test-summary/action@v2` can create check runs

Follow-up to #552 — setting job-level `permissions` restricts the `GITHUB_TOKEN` to only the listed scopes, so `test-summary/action` needs `checks: write` explicitly.

## Test plan
- [ ] CI passes and test summary check run is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test URL
https://fix/test-job-checks-permission--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
