### PR TITLE
fix(ci): restore semantic-release dry-run on all branches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Semantic Release (Dry Run)
-        if: github.ref == 'refs/heads/main'
         run: npm run semantic-release-dry
         env:
           GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Semantic Release (Dry Run)
+        if: startsWith(github.ref, 'refs/heads/')
         run: npm run semantic-release-dry
         env:
           GITHUB_TOKEN: ${{ secrets.ADOBE_BOT_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build-bundle": "rollup --config",
     "prepack": "npm run build-bundle",
     "semantic-release": "semantic-release",
-    "semantic-release-dry": "semantic-release --dry-run",
+    "semantic-release-dry": "semantic-release --dry-run --branches $CI_BRANCH",
     "prepare": "husky"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- Restores the semantic-release dry-run step on PR branches (was gated to `main`-only by #554)
- Uses `--branches $CI_BRANCH` instead of `--branches $CI_BRANCH 1.x main` to avoid `EINVALIDNEXTVERSION` errors when a release lands on `main` while a PR is open
- Removes the `if: github.ref == 'refs/heads/main'` guard from the workflow step

## Root cause
The original `--branches $CI_BRANCH 1.x main` told semantic-release to treat the feature branch, `1.x`, and `main` as co-existing release branches. Semantic-release enforces version range constraints across branches — when a new release (e.g. 2.46.2) landed on `main`, it constrained the feature branch to `>=2.46.1 <2.46.2`, making a `feat`-driven minor bump impossible.

Using only `--branches $CI_BRANCH` avoids cross-branch range conflicts while still computing the correct next version from existing git tags.

## Test plan
- [ ] Verify the dry-run step runs and passes on this PR
- [ ] Verify it still works on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test URL
https://fix/semantic-release-dry-run--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
