### PR TITLE
fix(test): resolve race condition in fromredirect test

### DIFF
--- a/test/it/fromredirect.test.html
+++ b/test/it/fromredirect.test.html
@@ -12,6 +12,7 @@
     };
     // we log what's being sent to the "server"
     window.called = [];
+    window.beaconsPending = [];
     // and navigator.sendBeacon has been replaced with
     // a call to fakeSendBeacon
     window.fakeSendBeacon = function (url, payload) {
@@ -19,10 +20,11 @@
       if (typeof payload === 'string') {
         window.called.push(JSON.parse(payload));
       } else {
-        // it's a blob
-        payload.text().then((text) => {
+        // it's a blob – track the promise so tests can await it
+        const p = payload.text().then((text) => {
           window.called.push(JSON.parse(text));
         });
+        window.beaconsPending.push(p);
       }
     };
   </script>
@@ -75,8 +77,8 @@
 
           await sendMouse({ type: 'click', position: [10, 10] });
 
-          // wait for Blob .text() promises in fakeSendBeacon to resolve
-          await new Promise((resolve) => setTimeout(resolve, 100));
+          // wait for all async Blob .text() promises in fakeSendBeacon to resolve
+          await Promise.all(window.beaconsPending);
 
           assert(window.called.some((call) => call.checkpoint === 'top'), 'top checkpoint missing');
           assert(window.called.some((call) => call.checkpoint === 'redirect'), 'redirect checkpoint missing');

--- a/test/it/fromredirect.test.html
+++ b/test/it/fromredirect.test.html
@@ -75,6 +75,9 @@
 
           await sendMouse({ type: 'click', position: [10, 10] });
 
+          // wait for Blob .text() promises in fakeSendBeacon to resolve
+          await new Promise((resolve) => setTimeout(resolve, 100));
+
           assert(window.called.some((call) => call.checkpoint === 'top'), 'top checkpoint missing');
           assert(window.called.some((call) => call.checkpoint === 'redirect'), 'redirect checkpoint missing');
           assert(window.called.some((call) => call.checkpoint === 'enter'), 'enter checkpoint missing');


### PR DESCRIPTION
## Summary
- Adds an async delay after click events in `fromredirect.test.html` to allow Blob payload promises to resolve before asserting
- Fixes a flaky test failure: `AssertionError: click checkpoint missing`

## Root cause
The test's `fakeSendBeacon` handles Blob payloads asynchronously via `payload.text().then(...)`, but the test asserted immediately after dispatching the click without waiting for the Blob `.text()` promise to resolve. The `click` checkpoint was fired (confirmed by `console.debug` in CI logs) but `window.called` hadn't been updated yet.

## Test plan
- [ ] Verify the `fromredirect` test passes consistently on CI (Chromium, Firefox, WebKit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test URL
https://fix/flaky-fromredirect-test--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
