### PR TITLE
fix(ci): sanitize branch name and guard against long DNS labels in PR…

### DIFF
--- a/.github/workflows/update-pr-description.yaml
+++ b/.github/workflows/update-pr-description.yaml
@@ -21,12 +21,14 @@ jobs:
               pull_number: context.issue.number
             });
 
-            // Replace any non-alphanumeric, non-hyphen character with '-' for AEM URLs
-            // (adopted from helix-rum-js)
-            const branchName = context.payload.pull_request.head.ref.replace(/[^a-zA-Z0-9-]/g, '-');
+            // Sanitize branch name: replace non-alphanumeric chars, collapse consecutive hyphens, trim leading/trailing hyphens
+            const branchName = context.payload.pull_request.head.ref
+              .replace(/[^a-zA-Z0-9-]/g, '-')
+              .replace(/-+/g, '-')
+              .replace(/^-+|-+$/g, '');
             const domainLabel = `${branchName}--helix-rum-enhancer--adobe`;
             const testContent = domainLabel.length > 63
-              ? 'Branch name is too long to generate a valid preview URL (DNS label exceeds 63 characters).'
+              ? `Branch name is too long to generate a valid preview URL (${domainLabel.length}/63 DNS label characters).`
               : `https://${domainLabel}.aem.page/test/fixtures/otsdk-with-banner.html`;
             const testSection = `
 

--- a/.github/workflows/update-pr-description.yaml
+++ b/.github/workflows/update-pr-description.yaml
@@ -21,11 +21,8 @@ jobs:
               pull_number: context.issue.number
             });
 
-            // Sanitize branch name: replace non-alphanumeric chars, collapse consecutive hyphens, trim leading/trailing hyphens
-            const branchName = context.payload.pull_request.head.ref
-              .replace(/[^a-zA-Z0-9-]/g, '-')
-              .replace(/-+/g, '-')
-              .replace(/^-+|-+$/g, '');
+            // Replace any non-alphanumeric, non-hyphen characters with a single '-' for AEM URLs
+            const branchName = context.payload.pull_request.head.ref.replace(/[^a-zA-Z0-9-]+/g, '-');
             const domainLabel = `${branchName}--helix-rum-enhancer--adobe`;
             const testContent = domainLabel.length > 63
               ? `Branch name is too long to generate a valid preview URL (${domainLabel.length}/63 DNS label characters).`

--- a/.github/workflows/update-pr-description.yaml
+++ b/.github/workflows/update-pr-description.yaml
@@ -21,13 +21,17 @@ jobs:
               pull_number: context.issue.number
             });
 
-            // Get the branch name from the PR head ref
-            const branchName = context.payload.pull_request.head.ref;
-            const testUrl = `https://${branchName}--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html`;
+            // Replace any non-alphanumeric, non-hyphen character with '-' for AEM URLs
+            // (adopted from helix-rum-js)
+            const branchName = context.payload.pull_request.head.ref.replace(/[^a-zA-Z0-9-]/g, '-');
+            const domainLabel = `${branchName}--helix-rum-enhancer--adobe`;
+            const testContent = domainLabel.length > 63
+              ? 'Branch name is too long to generate a valid preview URL (DNS label exceeds 63 characters).'
+              : `https://${domainLabel}.aem.page/test/fixtures/otsdk-with-banner.html`;
             const testSection = `
 
             ## Test URL
-            ${testUrl}
+            ${testContent}
             `;
 
             // Check if the test section already exists


### PR DESCRIPTION
… description URL

Replace /\//g with /[^a-zA-Z0-9-]/g (adopted from helix-rum-js) so any special character in branch names is handled, not just '/'. Also skip generating the preview URL when the DNS label would exceed 63 characters, adding an explanatory note to the PR description instead.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!


## Test URL
https://worktree-fix-update-description--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
