### PR TITLE
fix: strip query params from referrer source in navigate/enter checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ test-output.log
 .idea
 src
 test-results/test-results.json
-*.bak.worktrees
+*.bak
+.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ test-output.log
 .idea
 src
 test-results/test-results.json
-*.bak
+*.bak.worktrees

--- a/modules/index.js
+++ b/modules/index.js
@@ -217,7 +217,8 @@ function processQueue() {
 function addNavigationTracking() {
   // enter checkpoint when referrer is not the current page url
   const navigate = (source, type, perfEntry) => {
-    const payload = { source, target: document.visibilityState };
+    const sanitizedSource = source ? urlSanitizers.path(source) : source;
+    const payload = { source: sanitizedSource, target: document.visibilityState };
     /* c8 ignore next 13 */
     // prerendering cannot be tested yet with headless browsers
     if (document.prerendering) {

--- a/modules/index.js
+++ b/modules/index.js
@@ -217,8 +217,8 @@ function processQueue() {
 function addNavigationTracking() {
   // enter checkpoint when referrer is not the current page url
   const navigate = (source, type, perfEntry) => {
-    const sanitizedSource = source ? urlSanitizers.path(source) : source;
-    const payload = { source: sanitizedSource, target: document.visibilityState };
+    // eslint-disable-next-line object-curly-newline, max-len
+    const payload = { source: source && urlSanitizers.path(source), target: document.visibilityState };
     /* c8 ignore next 13 */
     // prerendering cannot be tested yet with headless browsers
     if (document.prerendering) {

--- a/test/it/navigation.referrer-params.test.html
+++ b/test/it/navigation.referrer-params.test.html
@@ -1,0 +1,60 @@
+<html lang="en_IE">
+
+<head>
+  <title>Test Runner</title>
+</head>
+
+<body>
+  <script type="module">
+    import { runTests } from '@web/test-runner-mocha';
+    import { expect } from '@esm-bundle/chai';
+
+    runTests(async () => {
+      describe('Navigation referrer query-param sanitization', () => {
+
+        it('strips query params from referrer before sending navigate checkpoint', async () => {
+          let called = [];
+          window.hlx = {
+            rum: {
+              sampleRUM: (...args) => {
+                called.push(args);
+              }
+            }
+          };
+
+          class MockPerformanceEntries {
+            getEntries() {
+              return [{ type: 'navigate', redirectCount: 0, redirectStart: 0, redirectEnd: 0 }];
+            }
+          }
+          window.PerformanceObserver = class {
+            constructor(cb) { this.cb = cb; }
+            observe() { this.cb(new MockPerformanceEntries()); }
+          };
+
+          const referrerWithParams = new URL('/test/fixtures/referrer.html?tracking=abc&session=xyz', window.location);
+          window.hlx.referrer = referrerWithParams.href;
+
+          const script = document.createElement('script');
+          script.src = new URL('/modules/index.js', window.location).href;
+          script.type = 'module';
+          document.head.appendChild(script);
+
+          await new Promise((resolve) => { script.onload = resolve; });
+          await new Promise((resolve) => { setTimeout(resolve, 1000); });
+
+          const navigateCall = called.find((c) => c[0] === 'navigate');
+          expect(navigateCall, 'navigate checkpoint must be fired').to.exist;
+          expect(navigateCall[1].source).to.not.include('?', 'navigate source must not contain query params');
+          expect(navigateCall[1].source).to.equal(
+            `${window.location.origin}/test/fixtures/referrer.html`,
+            'navigate source must be origin + pathname only',
+          );
+        });
+
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/test/it/navigation.test.html
+++ b/test/it/navigation.test.html
@@ -54,7 +54,7 @@
             }
           };
 
-          const url = new URL('/test/fixtures/referrer.html', window.location);
+          const url = new URL('/test/fixtures/referrer.html?tracking=abc&session=xyz', window.location);
           window.hlx.referrer = url.href;
 
 
@@ -77,6 +77,12 @@
           expect(called[2][0]).to.equal('back_forward');
           expect(called[3][0]).to.equal('prerender');
           expect(called[4][0]).to.equal('language');
+
+          // referrer had query params — source must be stripped to origin+pathname only
+          expect(called[0][1].source).to.not.include('?', 'navigate source must not contain query params');
+          expect(called[0][1].source).to.equal(
+            window.location.origin + '/test/fixtures/referrer.html',
+          );
         });
 
       });

--- a/test/it/navigation.test.html
+++ b/test/it/navigation.test.html
@@ -54,7 +54,7 @@
             }
           };
 
-          const url = new URL('/test/fixtures/referrer.html?tracking=abc&session=xyz', window.location);
+          const url = new URL('/test/fixtures/referrer.html', window.location);
           window.hlx.referrer = url.href;
 
 
@@ -77,12 +77,6 @@
           expect(called[2][0]).to.equal('back_forward');
           expect(called[3][0]).to.equal('prerender');
           expect(called[4][0]).to.equal('language');
-
-          // referrer had query params — source must be stripped to origin+pathname only
-          expect(called[0][1].source).to.not.include('?', 'navigate source must not contain query params');
-          expect(called[0][1].source).to.equal(
-            window.location.origin + '/test/fixtures/referrer.html',
-          );
         });
 
       });


### PR DESCRIPTION
## Summary

- The `navigate` and `enter` checkpoints were sending `document.referrer` unsanitized as `source`. For same-origin navigation, `document.referrer` includes the full previous URL with query params.
- Fixed by sanitizing through `urlSanitizers.path()` before placing in the checkpoint payload. The original value is still used for navigation type detection (`navigate` vs `enter` vs `reload`).

## Why

The [operational telemetry docs](https://www.aem.live/docs/operational-telemetry) state that URL parameters will not be collected or stored. The collector strips params before storage, but the `source` field for `navigate`/`enter` was still transmitting params in the beacon for same-origin navigation. This aligns client-side behaviour with the documented privacy guarantee.

## Test plan

- [ ] Verify `navigate`/`enter` checkpoint `source` strips query params from same-origin referrer
- [ ] Navigation type detection (navigate vs enter vs reload) still works correctly
- [ ] All existing tests pass (289/289 Chromium+Firefox)

Generated with [Claude Code](https://claude.com/claude-code)

Before: https://main--helix-rum-enhancer--adobe.aem.live/test/fixtures/otsdk-with-banner.html
After: https://fix-sanitize-referrer-params--helix-rum-enhancer--adobe.aem.live/test/fixtures/otsdk-with-banner.html

## Test URL
https://fix-sanitize-referrer-params--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
