### PR TITLE
fix(form): accurately detect formsubmit using e.defaultPrevented (FORMS-16836)

### DIFF
--- a/plugins/form.js
+++ b/plugins/form.js
@@ -23,42 +23,82 @@ export const getSubmitType = (el) => {
 };
 
 let rootMo = null;
+let submitListenerInstalled = false;
+const firedForms = new WeakSet();
+
+// Field-level validation signals across native, ARIA, Marketo, and Bootstrap conventions.
+const ERROR_FIELD_SELECTORS = ':invalid, [aria-invalid="true"], .mktoInvalid, .is-invalid';
+// Generic visible error-message containers (e.g. Revolt.tv .error-message divs).
+const ERROR_TEXT_SELECTORS = '[class*="error" i]:not(:empty), [class*="invalid" i]:not(:empty), [role="alert"]:not(:empty)';
+
+function reportFieldErrors(form, sampleRUM, sourceSelector) {
+  const invalidFields = form.querySelectorAll(ERROR_FIELD_SELECTORS);
+  invalidFields.forEach((field) => {
+    if (field && field.validity) {
+      const prototype = Object.getPrototypeOf(field.validity);
+      const errorType = prototype
+        ? Object.keys(Object.getOwnPropertyDescriptors(prototype))
+          .filter((key) => key !== 'valid' && key !== 'constructor' && !key.startsWith('Symbol'))
+          .find((key) => field.validity[key]) || 'custom'
+        : 'custom';
+      sampleRUM('error', { target: errorType, source: sourceSelector(field) });
+    }
+  });
+  return invalidFields.length > 0;
+}
+
+function hasVisibleErrorText(form) {
+  return [...form.querySelectorAll(ERROR_TEXT_SELECTORS)]
+    .some((el) => el.offsetParent !== null && el.textContent.trim());
+}
+
+function fireFormSubmit(form, sampleRUM, sourceSelector, targetSelector) {
+  if (firedForms.has(form)) {
+    return;
+  }
+  firedForms.add(form);
+  sampleRUM(getSubmitType(form), {
+    target: targetSelector(form),
+    source: sourceSelector(form),
+  });
+}
 
 export default function addFormTracking({
   createMO,
   sampleRUM, sourceSelector, targetSelector, context, getIntersectionObserver,
 }) {
-  // Track existing forms
+  // Install ONE document-level submit listener for the whole page.
+  // Bubble phase on document runs after every per-form handler, so
+  // e.defaultPrevented reflects the final decision: did anything cancel the submission?
+  if (!submitListenerInstalled) {
+    submitListenerInstalled = true;
+    document.addEventListener('submit', (e) => {
+      const form = e.target;
+      if (!form || form.tagName !== 'FORM') {
+        return;
+      }
+
+      if (!e.defaultPrevented) {
+        // Nothing cancelled it - form will navigate. Fire synchronously so
+        // sendBeacon survives the page unload. Native validation already
+        // blocked invalid submissions before reaching us.
+        fireFormSubmit(form, sampleRUM, sourceSelector, targetSelector);
+        return;
+      }
+
+      // preventDefault was called - form is staying on this page.
+      // Defer one tick so framework validators can populate error indicators.
+      setTimeout(() => {
+        const hasFieldErrors = reportFieldErrors(form, sampleRUM, sourceSelector);
+        if (hasFieldErrors || hasVisibleErrorText(form)) {
+          return;
+        }
+        fireFormSubmit(form, sampleRUM, sourceSelector, targetSelector);
+      }, 0);
+    });
+  }
 
   function trackForm(form) {
-    form.addEventListener('submit', (e) => {
-      // Check for form validation errors before submitting
-      const invalidFields = form.querySelectorAll(':invalid');
-      // Send error checkpoints for each invalid field
-      invalidFields.forEach((field) => {
-        if (field && field.validity) {
-          const prototype = Object.getPrototypeOf(field.validity);
-          const errorType = prototype
-            ? Object.keys(Object.getOwnPropertyDescriptors(prototype))
-              .filter((key) => key !== 'valid' && key !== 'constructor' && !key.startsWith('Symbol'))
-              .find((key) => field.validity[key]) || 'custom'
-            : 'custom';
-
-          sampleRUM('error', {
-            target: errorType,
-            source: sourceSelector(field),
-          });
-        }
-      });
-      // Only send formsubmit event if there are no validation errors
-      if (invalidFields.length === 0) {
-        sampleRUM(getSubmitType(e.target), {
-          target: targetSelector(e.target),
-          source: sourceSelector(e.target),
-        });
-      }
-    }, { once: true });
-
     getIntersectionObserver('viewblock').observe(form);
     let lastSource;
     form.addEventListener('change', (e) => {

--- a/test/unit/form-validation.test.html
+++ b/test/unit/form-validation.test.html
@@ -58,15 +58,86 @@
     <input type="submit" value="Submit Multiple Errors Form">
   </form>
 
+  <!-- Test 8: SPA-style form — novalidate, sets aria-invalid asynchronously (React/Vue pattern) -->
+  <form id="spa-form" class="test-form" novalidate action="javascript:false;" method="POST">
+    <input type="text" name="email" placeholder="Email">
+    <input type="submit" value="Submit SPA Form">
+  </form>
+
+  <!-- Test 9: Marketo-style form — adds .mktoInvalid synchronously on submit -->
+  <form id="marketo-form" class="test-form mktoForm" novalidate action="javascript:false;" method="POST">
+    <input type="text" name="FirstName" placeholder="First Name">
+    <input type="submit" value="Submit Marketo Form">
+  </form>
+
+  <!-- Test 10: Bootstrap-style form — adds .is-invalid synchronously on submit -->
+  <form id="bootstrap-form" class="test-form" novalidate action="javascript:false;" method="POST">
+    <input type="text" name="email" placeholder="Email">
+    <input type="submit" value="Submit Bootstrap Form">
+  </form>
+
+  <!-- Test 11: SPA-style form with no validation errors (clean valid submit) -->
+  <form id="spa-valid-form" class="test-form" novalidate action="javascript:false;" method="POST">
+    <input type="text" name="email" placeholder="Email">
+    <input type="submit" value="Submit SPA Valid Form">
+  </form>
+
+  <!-- Test 12: Revolt.tv-style form — populates .error-message divs synchronously, no aria/native signals -->
+  <form id="revolt-form" class="test-form" action="javascript:false;" method="POST">
+    <input type="text" name="email" placeholder="Email">
+    <div class="error-message" data-target="email"></div>
+    <input type="submit" value="Submit Revolt Form">
+  </form>
+
+  <!-- Test 13: Native form that will "navigate" (no preventDefault) — must fire formsubmit synchronously -->
+  <form id="navigation-form" class="test-form" action="javascript:false;" method="POST">
+    <input type="text" name="email" value="test@example.com">
+    <input type="submit" value="Submit Navigation Form">
+  </form>
+
   <script>
-    // Prevent form submission to avoid navigation during tests
-    document.querySelectorAll('form').forEach(form => {
+    // Prevent navigation during tests (no stopPropagation — events MUST bubble to document
+    // so the new document-level submit listener can read e.defaultPrevented).
+    // The navigation-form is excluded — it tests the no-preventDefault path.
+    document.querySelectorAll('form:not(#spa-form):not(#spa-valid-form):not(#marketo-form):not(#bootstrap-form):not(#revolt-form):not(#navigation-form)').forEach(form => {
       form.addEventListener('submit', (e) => {
         e.preventDefault();
-        e.stopPropagation();
-        return false;
       });
     });
+
+    // SPA form (invalid): validates on submit, sets aria-invalid asynchronously (React setState + re-render)
+    document.querySelector('#spa-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      setTimeout(() => {
+        document.querySelector('#spa-form input[name="email"]').setAttribute('aria-invalid', 'true');
+      }, 0);
+    });
+
+    // Marketo-style: sets .mktoInvalid synchronously
+    document.querySelector('#marketo-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      document.querySelector('#marketo-form input[name="FirstName"]').classList.add('mktoInvalid');
+    });
+
+    // Bootstrap-style: sets .is-invalid synchronously
+    document.querySelector('#bootstrap-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      document.querySelector('#bootstrap-form input[name="email"]').classList.add('is-invalid');
+    });
+
+    // SPA valid form: just prevents default, no errors set
+    document.querySelector('#spa-valid-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+    });
+
+    // Revolt.tv-style: preventDefault and populate error-message div with text synchronously
+    // No :invalid, no aria-invalid, no framework classes — only visible error text.
+    document.querySelector('#revolt-form').addEventListener('submit', (e) => {
+      e.preventDefault();
+      document.querySelector('#revolt-form .error-message').textContent = 'Please enter a valid email address.';
+    });
+
+    // navigation-form has NO submit handler — defaultPrevented stays false → sync path fires formsubmit.
   </script>
 
   <script type="module">
@@ -452,6 +523,134 @@
              'rangeUnderflow', 'rangeOverflow', 'stepMismatch', 'badInput', 'customError'].includes(call.target)
           );
           expect(specificErrors.length).to.be.at.least(1, 'Should have specific error types detected');
+        });
+
+        it('should NOT fire formsubmit when Marketo sets .mktoInvalid synchronously', async function test() {
+          const form = document.querySelector('#marketo-form');
+          window.called = [];
+
+          addFormTracking({
+            sampleRUM: mockSampleRUM,
+            sourceSelector: mockSourceSelector,
+            targetSelector: mockTargetSelector,
+            context: document,
+            createMO: mockCreateMO,
+            getIntersectionObserver: mockGetIntersectionObserver,
+          });
+
+          form.querySelector('input[type="submit"]').click();
+
+          await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+          const submitCalls = window.called.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submitCalls.length).to.equal(0, 'formsubmit must not fire when .mktoInvalid is set');
+        });
+
+        it('should NOT fire formsubmit when Bootstrap sets .is-invalid synchronously', async function test() {
+          const form = document.querySelector('#bootstrap-form');
+          window.called = [];
+
+          addFormTracking({
+            sampleRUM: mockSampleRUM,
+            sourceSelector: mockSourceSelector,
+            targetSelector: mockTargetSelector,
+            context: document,
+            createMO: mockCreateMO,
+            getIntersectionObserver: mockGetIntersectionObserver,
+          });
+
+          form.querySelector('input[type="submit"]').click();
+
+          await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+          const submitCalls = window.called.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submitCalls.length).to.equal(0, 'formsubmit must not fire when .is-invalid is set');
+        });
+
+        it('should NOT fire formsubmit when framework sets aria-invalid asynchronously', async function test() {
+          const form = document.querySelector('#spa-form');
+          window.called = [];
+
+          addFormTracking({
+            sampleRUM: mockSampleRUM,
+            sourceSelector: mockSourceSelector,
+            targetSelector: mockTargetSelector,
+            context: document,
+            createMO: mockCreateMO,
+            getIntersectionObserver: mockGetIntersectionObserver,
+          });
+
+          form.querySelector('input[type="submit"]').click();
+
+          // Wait past our deferred check (setTimeout 0)
+          await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+          const submitCalls = window.called.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submitCalls.length).to.equal(0, 'formsubmit must not fire when aria-invalid is set by framework');
+        });
+
+        it('should fire formsubmit when SPA form has no aria-invalid errors', async function test() {
+          const form = document.querySelector('#spa-valid-form');
+          window.called = [];
+
+          addFormTracking({
+            sampleRUM: mockSampleRUM,
+            sourceSelector: mockSourceSelector,
+            targetSelector: mockTargetSelector,
+            context: document,
+            createMO: mockCreateMO,
+            getIntersectionObserver: mockGetIntersectionObserver,
+          });
+
+          form.querySelector('input[type="submit"]').click();
+
+          await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+          const submitCalls = window.called.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submitCalls.length).to.be.at.least(1, 'formsubmit must fire when SPA form has no errors');
+        });
+
+        it('should NOT fire formsubmit when form populates an .error-message div (Revolt.tv pattern)', async function test() {
+          const form = document.querySelector('#revolt-form');
+          window.called = [];
+
+          addFormTracking({
+            sampleRUM: mockSampleRUM,
+            sourceSelector: mockSourceSelector,
+            targetSelector: mockTargetSelector,
+            context: document,
+            createMO: mockCreateMO,
+            getIntersectionObserver: mockGetIntersectionObserver,
+          });
+
+          form.querySelector('input[type="submit"]').click();
+
+          await new Promise((resolve) => { setTimeout(resolve, 100); });
+
+          const submitCalls = window.called.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submitCalls.length).to.equal(0, 'formsubmit must not fire when an error-message div has text');
+        });
+
+        it('should fire formsubmit SYNCHRONOUSLY when form does not preventDefault (navigation path)', async function test() {
+          const form = document.querySelector('#navigation-form');
+          window.called = [];
+
+          addFormTracking({
+            sampleRUM: mockSampleRUM,
+            sourceSelector: mockSourceSelector,
+            targetSelector: mockTargetSelector,
+            context: document,
+            createMO: mockCreateMO,
+            getIntersectionObserver: mockGetIntersectionObserver,
+          });
+
+          // Dispatch a synthetic submit event (no preventDefault called, no real navigation).
+          // The sync path must fire formsubmit immediately, before any setTimeout could run.
+          form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+          // No await — verify formsubmit is already present synchronously.
+          const submitCalls = window.called.filter((c) => c.checkpoint === 'formsubmit');
+          expect(submitCalls.length).to.be.at.least(1, 'formsubmit must fire synchronously when nothing prevents the submit');
         });
 
       });


### PR DESCRIPTION
## Summary

Fixes [FORMS-16836](https://jira.corp.adobe.com/browse/FORMS-16836): `formsubmit` checkpoint fires on validation failures, inflating reported conversion rates on sites like Twilio, Revolt.tv, Surest, and Maidenform.

### Root cause

The previous check (`form.querySelectorAll(':invalid')`) only sees native HTML5 validation. Most modern forms use `novalidate` + JS validation (React, Marketo, Bootstrap, custom), so `:invalid` is always empty and `formsubmit` fires even when validation visibly failed.

### Approach

Rearchitect submit tracking around `e.defaultPrevented` — the authoritative signal for whether a form will actually navigate:

- **Single document-level submit listener (bubble phase)** runs after every per-form handler, so `defaultPrevented` reflects the final decision.
- **`defaultPrevented === false`** → form will navigate. Fire `formsubmit` synchronously so `sendBeacon` survives page unload.
- **`defaultPrevented === true`** → form is JS-handled (no navigation). Defer one tick, then check for error indicators before firing.

Error detection in the deferred path covers:
- `:invalid` — native HTML5 constraint validation
- `[aria-invalid="true"]` — ARIA standard (React, Vue, accessible SPAs)
- `.mktoInvalid` — Marketo Forms 2.0
- `.is-invalid` — Bootstrap
- Visible non-empty `[class*="error"]`, `[class*="invalid"]`, `[role="alert"]` — custom patterns (e.g. Revolt.tv's `.error-message` divs)

### Verification against real production forms

| URL | OLD `formsubmit` count | NEW `formsubmit` count |
|---|---|---|
| `twilio.com/en-us/help/sales` (Marketo) | 1 | 0 |
| `revolt.tv/newsletter-single` | 1 | 0 |
| `revolt.tv/newsletter` | 1 | 0 |
| `surest.com/contact-us` (Marketo) | 2 | 0 |

Tested via Playwright with the actual built plugin injected into each page; failed submissions correctly produce zero `formsubmit` checkpoints with the new code.

## Test plan

- [x] Unit tests: 14 cases including SPA (async `aria-invalid`), Marketo (`.mktoInvalid`), Bootstrap (`.is-invalid`), Revolt.tv (`.error-message` text), valid SPA submissions, and the new synchronous navigation path
- [x] Full suite passes across Chromium, Firefox, WebKit
- [x] Lint clean
- [x] Manual verification against all reproducible Jira-reported URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)