### PR TITLE
fix(form): detect Marketo .mktoInvalid as a validation failure (FORMS-16836)

### DIFF
--- a/plugins/form.js
+++ b/plugins/form.js
@@ -33,7 +33,7 @@ export default function addFormTracking({
   function trackForm(form) {
     form.addEventListener('submit', (e) => {
       // Check for form validation errors before submitting
-      const invalidFields = form.querySelectorAll(':invalid');
+      const invalidFields = form.querySelectorAll(':invalid, .mktoInvalid');
       // Send error checkpoints for each invalid field
       invalidFields.forEach((field) => {
         if (field && field.validity) {


### PR DESCRIPTION
Adds \`.mktoInvalid\` to the invalid-field selector so Marketo forms are caught by the existing validation check.

\`\`\`diff
- const invalidFields = form.querySelectorAll(':invalid');
+ const invalidFields = form.querySelectorAll(':invalid, .mktoInvalid');
\`\`\`

Marketo Forms 2.0 set \`novalidate\` on the form element, so \`:invalid\` is always empty even when the user leaves required fields blank. Marketo instead marks invalid fields with \`.mktoInvalid\`. Without this fix, \`formsubmit\` fires on failed submissions, inflating conversion counts.

**Validated on production:**

| URL | Before | After |
|---|---|---|
| twilio.com/en-us/help/sales | formsubmit fires | no formsubmit |
| surest.com/contact-us | formsubmit fires | no formsubmit |