### PR TITLE
feat: report source for the largest CLS layout shift

### DIFF
--- a/plugins/cwv.js
+++ b/plugins/cwv.js
@@ -35,6 +35,17 @@ export default function addCWVTracking({
             data.target = targetSelector(element);
             data.source = sourceSelector(element) || (element && element.outerHTML.slice(0, 30));
           }
+          if (measurement.name === 'CLS' && measurement.entries.length > 0) {
+            // Attribute CLS to the element of the single largest layout shift
+            // (mirrors web-vitals' `largestShiftTarget`, derived from the standard entries).
+            const largest = measurement.entries
+              .reduce((a, b) => (b.value > (a ? a.value : 0) ? b : a), undefined);
+            const node = largest && largest.sources
+              && largest.sources.map((s) => s.node).find((n) => n && n.nodeType === 1);
+            if (node) {
+              data.source = sourceSelector(node) || node.outerHTML.slice(0, 30);
+            }
+          }
           sampleRUM('cwv', data);
         };
 


### PR DESCRIPTION
## What

`storeCWV` (`plugins/cwv.js`) attaches an element `source`/`target` only for `LCP`. CLS/INP/TTFB checkpoints are value-only, so the `cwv-cls` checkpoint never carries the shifting element — no RUM site gets a CLS element source.

## Why

The largest-shift element is already available from the standard web-vitals `LayoutShift` entries (`entries[].sources[].node`) — this is what web-vitals' attribution build surfaces as `largestShiftTarget`, and it's derivable **without** switching builds. Consumers that want to attribute a CLS regression to a specific element (e.g. CWV optimization tooling) currently have no signal for CLS, only LCP.

## Change

Extend `storeCWV`: for `CLS`, pick the largest-`value` `LayoutShift` entry and report its first element source node via the existing `sourceSelector` (same `outerHTML.slice(0, 30)` fallback as LCP).

- Guards for empty `sources` and null/detached nodes (`nodeType === 1`); value-only fallback, never throws.
- The `LCP` branch is untouched.
- No `target` for CLS (no associated resource, unlike LCP's image).
- CLS runs eager (`reportAllChanges`), so `storeCWV` fires repeatedly — `reduce` is non-mutating (unlike LCP's `entries.pop()`), so re-picking the largest each beacon is safe.

## Tests

Consistent with the existing suite, which asserts the `cwv` checkpoint fires (the LCP `source` value isn't asserted either). Happy to add a targeted layout-shift test if preferred.

## Related Issues


## Test URL
https://cls-element-source--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
