### PR TITLE
feat: flag untrusted (synthetic) clicks as bots

### DIFF
--- a/modules/defaults.js
+++ b/modules/defaults.js
@@ -11,6 +11,6 @@
  */
 import { fflags } from './fflags.js';
 
-export const KNOWN_PROPERTIES = ['weight', 'id', 'referer', 'checkpoint', 't', 'source', 'target', 'cwv', 'CLS', 'FID', 'LCP', 'INP', 'TTFB'];
+export const KNOWN_PROPERTIES = ['weight', 'id', 'referer', 'checkpoint', 't', 'source', 'target', 'cwv', 'CLS', 'FID', 'LCP', 'INP', 'TTFB', 'ua'];
 export const DEFAULT_TRACKING_EVENTS = ['click', 'cwv', 'form', 'viewblock', 'viewmedia', 'loadresource', 'utm', 'paid', 'email', 'consent'];
 fflags.enabled('example', () => DEFAULT_TRACKING_EVENTS.push('example'));

--- a/modules/dom.js
+++ b/modules/dom.js
@@ -32,6 +32,14 @@ export const targetSelector = (el) => {
   }
 };
 
+export const untrustedClickPayload = (event) => {
+  if (event && event.isTrusted === false) {
+    const ua = navigator.userAgent;
+    return { ua: ua.includes('+http') ? ua : `${ua} +http://event.untrusted` };
+  }
+  return {};
+};
+
 function walk(el, check) {
   if (!el || el === document.body || el === document.documentElement) {
     return undefined;

--- a/modules/index.js
+++ b/modules/index.js
@@ -13,7 +13,7 @@
 
 import { KNOWN_PROPERTIES, DEFAULT_TRACKING_EVENTS } from './defaults.js';
 import { urlSanitizers } from './utils.js';
-import { targetSelector, sourceSelector } from './dom.js';
+import { targetSelector, sourceSelector, untrustedClickPayload } from './dom.js';
 import { fflags } from './fflags.js';
 
 const { sampleRUM, queue, isSelected } = (window.hlx && window.hlx.rum) ? window.hlx.rum
@@ -127,6 +127,7 @@ const PLUGIN_PARAMS = {
   sampleRUM,
   sourceSelector,
   targetSelector,
+  untrustedClickPayload,
   getIntersectionObserver,
   createMO,
 };
@@ -371,7 +372,8 @@ function addTrackingFromConfig() {
     if (event.optelHandled) {
       return;
     }
-    sampleRUM('click', { target: targetSelector(event.target), source: sourceSelector(event.target) });
+    // eslint-disable-next-line max-len
+    sampleRUM('click', { target: targetSelector(event.target), source: sourceSelector(event.target), ...untrustedClickPayload(event) });
   });
 
   // Core tracking

--- a/plugins/webcomponent.js
+++ b/plugins/webcomponent.js
@@ -23,6 +23,7 @@ export default function addWebComponentTracking({
   sampleRUM,
   sourceSelector,
   targetSelector,
+  untrustedClickPayload,
   createMO,
 }) {
   /**
@@ -90,7 +91,8 @@ export default function addWebComponentTracking({
           }
           // eslint-disable-next-line no-param-reassign
           event.optelHandled = true;
-          sampleRUM('click', { target: targetSelector(event.target), source: sourceSelector(event.target) });
+          // eslint-disable-next-line max-len
+          sampleRUM('click', { target: targetSelector(event.target), source: sourceSelector(event.target), ...untrustedClickPayload(event) });
         });
       }
       // look for web components below this element

--- a/test/it/click.test.html
+++ b/test/it/click.test.html
@@ -96,6 +96,17 @@
           });
           assert(window.called.length === 4, 'checkpoint for click on late added link missing');
           assert(window.called[3].source === 'a#alatelink', 'invalid target for alatelink checkpoint');
+
+          // trusted clicks (sendMouse) must not carry a ua field
+          assert(window.called[0].ua === undefined, 'trusted click should not have a ua field');
+          assert(window.called[1].ua === undefined, 'trusted click should not have a ua field');
+          // synthetic clicks (element.click()) are untrusted and must carry a ua marker
+          assert(typeof window.called[2].ua === 'string', 'untrusted click missing ua field');
+          assert(window.called[2].ua.endsWith('+http://event.untrusted'),
+            `ua ${window.called[2].ua} does not end with untrusted marker`);
+          assert(window.called[3].ua.endsWith('+http://event.untrusted'),
+            `ua ${window.called[3].ua} does not end with untrusted marker`);
+
           // Test max events
           const maxEvents = 1026 - window.events.length;
           for (let i = 0; i < maxEvents; i++) {

--- a/test/unit/defaults.test.js
+++ b/test/unit/defaults.test.js
@@ -24,6 +24,10 @@ describe('test defaults', () => {
     });
   });
 
+  it('KNOWN_PROPERTIES includes ua', () => {
+    expect(KNOWN_PROPERTIES).to.include('ua');
+  });
+
   it('DEFAULT_TRACKING_EVENTS is an array of string', () => {
     // eslint-disable-next-line no-unused-expressions
     expect(Array.isArray(DEFAULT_TRACKING_EVENTS)).to.be.true;

--- a/test/unit/dom.test.js
+++ b/test/unit/dom.test.js
@@ -13,7 +13,9 @@
 /* eslint-env mocha */
 
 import { expect } from '@esm-bundle/chai';
-import { getTargetValue, targetSelector, sourceSelector } from '../../modules/dom.js';
+import {
+  getTargetValue, targetSelector, sourceSelector, untrustedClickPayload,
+} from '../../modules/dom.js';
 
 describe('test dom#getTargetValue', () => {
   it('getTargetValue - basics', () => {
@@ -143,5 +145,53 @@ describe('test dom#sourceSelector', () => {
     expect(sourceSelector(form1)).to.be.equal('#contentcontainer-9065752e10 form#\\33 89');
     expect(sourceSelector(form2)).to.be.equal('form.\\31 23abc');
     expect(sourceSelector(form3)).to.be.equal('form#eec6b0d9-bd39-42aa-9f96-29a7aced9765\\/root\\/container\\/modal');
+  });
+});
+
+describe('test dom#untrustedClickPayload', () => {
+  it('untrustedClickPayload - basics', () => {
+    expect(untrustedClickPayload).to.be.a('function');
+  });
+
+  it('untrustedClickPayload - trusted event returns empty object', () => {
+    expect(untrustedClickPayload({ isTrusted: true })).to.deep.equal({});
+  });
+
+  it('untrustedClickPayload - missing event returns empty object', () => {
+    expect(untrustedClickPayload()).to.deep.equal({});
+  });
+
+  it('untrustedClickPayload - untrusted event returns ua with marker', () => {
+    const { ua } = untrustedClickPayload({ isTrusted: false });
+    expect(ua).to.be.a('string');
+    // eslint-disable-next-line no-unused-expressions
+    expect(ua.endsWith('+http://event.untrusted')).to.be.true;
+  });
+
+  it('untrustedClickPayload - does not double append when ua already has +http', function test() {
+    const original = navigator.userAgent;
+    let overridden = false;
+    try {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: 'TestBot +http://bot.example',
+        configurable: true,
+      });
+      overridden = navigator.userAgent === 'TestBot +http://bot.example';
+    } catch (e) {
+      overridden = false;
+    }
+    if (!overridden) {
+      this.skip();
+      return;
+    }
+    try {
+      const { ua } = untrustedClickPayload({ isTrusted: false });
+      expect(ua).to.be.equal('TestBot +http://bot.example');
+    } finally {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        value: original,
+        configurable: true,
+      });
+    }
   });
 });


### PR DESCRIPTION
## What

Adds a client-side bot signal for **JS-synthesized clicks** — those with `event.isTrusted === false` (i.e. `element.click()` or `dispatchEvent(new MouseEvent(...))`). When a tracked click is untrusted, the click beacon carries a `ua` field with a `+http://event.untrusted` marker appended to the User-Agent.

This reuses the exact convention the base library (`helix-rum-js`) already uses for `navigator.webdriver` (appending `+http://navigator.webdriver`): the collector's `isbot` classifier flags any UA containing `+http`. **No collector change and no new analytics schema** — just one allowlisted field.

## How

- `modules/dom.js`: new `untrustedClickPayload(event)` helper — returns `{}` for trusted/missing events, `{ ua: '<userAgent> +http://event.untrusted' }` for untrusted (with a double-append guard when the UA already contains `+http`).
- `modules/index.js`: helper spread into the core `click` beacon and exposed to plugins via the plugin params object.
- `plugins/webcomponent.js`: same treatment for shadow-root clicks.
- `modules/defaults.js`: `ua` added to `KNOWN_PROPERTIES` (the `JSON.stringify` allowlist) so the field is not stripped.
- Tests: unit (`dom.test.js`, `defaults.test.js`) and integration (`click.test.html`) — untrusted click emits the marker; trusted click has no `ua`.

## Scope / non-goals

- Trusted clicks are byte-identical to before (no `ua` field).
- Does **not** detect CDP `Input.dispatchMouseEvent` (those are `isTrusted: true`; catching them needs behavioral heuristics — deferred).
- `navigator.webdriver`-mode automation is already handled upstream in `helix-rum-js`.
- No raw coordinates or PII added to beacons.

## Bundle size

Stacked on the minification PR (#588) so the core bundle stays under the 16 KB budget: `src/index.js` = **16,334 bytes** (< 16,384; net-zero vs. original main — 19 bytes under 16,353).

## Verification

- `npm run lint` passes.
- `npm test` passes across Chromium / Firefox / WebKit (0 failed), including the new untrusted-click tests and the size budget check.

URL for testing:

- https://flag-untrusted-clicks-as-bots--helix-rum-enhancer--adobe.aem.page/

---

**Stacked on #588** — targets `minify-bundle` and should be merged after #588 (or re-target to `main` once #588 lands).

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author