### PR TITLE
feat: track OpenAI (ChatGPT) ad click IDs

### DIFF
--- a/plugins/martech.js
+++ b/plugins/martech.js
@@ -19,7 +19,7 @@ function addAdsParametersTracking(usp, { sampleRUM }) {
     linkedin: /li_fat_id/,
     pinterest: /epik/,
     tiktok: /ttclid/,
-    openai: /oppref|olref/,
+    openai: /o(pp|l)ref/,
   };
   const params = Array.from(usp.keys());
   Object.entries(networks).forEach(([network, regex]) => {

--- a/plugins/martech.js
+++ b/plugins/martech.js
@@ -19,6 +19,7 @@ function addAdsParametersTracking(usp, { sampleRUM }) {
     linkedin: /li_fat_id/,
     pinterest: /epik/,
     tiktok: /ttclid/,
+    openai: /oppref|olref/,
   };
   const params = Array.from(usp.keys());
   Object.entries(networks).forEach(([network, regex]) => {


### PR DESCRIPTION
## What

Adds an `openai` ad network to the martech click-ID tracking in `plugins/martech.js`, matching the `oppref` and `olref` query parameters:

```js
openai: /o(pp|l)ref/
```

## Why

OpenAI appends these params to the landing URL when a user clicks a **ChatGPT ad**. `oppref` is documented as an "OpenAI-provided privacy-preserving attribution identifier" ([developers.openai.com/ads](https://developers.openai.com/ads)); `olref` is the companion token that rides along on the same clicks. They are the OpenAI equivalent of `gclid` (Google), `msclkid` (Microsoft), `fbclid` (Meta), `ttclid` (TikTok), etc.

Example ChatGPT ad landing URL:
```
https://www.example.com/product?utm_source=openai&utm_medium=paid_openai&oppref=gAAAAAB…&olref=gAAAAAB…
```

Because these tokens are appended by OpenAI's ad pipeline (not set by the advertiser), they reliably identify paid ChatGPT traffic even when the advertiser doesn't add `utm_*` tags of their own.

## Effect

Requests carrying `oppref`/`olref` now emit a `paid` checkpoint with `source: openai`, consistent with the handling of every other ad network in this list. No other behavior changes.

## Notes

- `oppcref` (a plaintext-UUID param seen on some sites) is intentionally **not** matched — it is an advertiser-internal parameter, not an OpenAI attribution token.
- Follows the existing unanchored-regex convention used for the other networks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test URL
https://add-openai-click-ids--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
