### PR TITLE
enabling allresources for customer

### DIFF
--- a/modules/fflags.js
+++ b/modules/fflags.js
@@ -17,6 +17,6 @@ export const fflags = {
   disabled: (f, c) => !fflags.has(f) && c(),
   eagercwv: [683],
   example: [543, 770, 1136],
-  allresources: [543, 1139, 397],
+  allresources: [543, 1139, 339],
   a11y: [557, 781, 897, 955, 959],
 };


### PR DESCRIPTION
allresources was enabled for old domain but customer has a new domain now. Switching to the new one

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!


## Test URL
https://customer-allresources-flag--helix-rum-enhancer--adobe.aem.page/test/fixtures/otsdk-with-banner.html
